### PR TITLE
Improve coding style

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required(VERSION 3.18...3.22)
 
 project(impalib VERSION "0.1.0" LANGUAGES CXX)
 
+set(CMAKE_CXX_STANDARD 17)
+
 include(GNUInstallDirs)
 
 add_library(impalib INTERFACE)

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ We assume in the code samples below you've copied them to an `impalib` subdirect
                               pMAX_STATE);
           model_graph.iterate(pNON_ZERO_WEIGHT_INDICES_SIZES);
           for (int i=0; i<N_TEAMS; i++) {
-              cout << model_graph.outputs.ExtrinsicOutputTeam[i]+model_graph.modelInputs_.RewardTeam[i]<<endl;
+              cout << model_graph.outputs.extrinsic[i]+model_graph.inputs_.RewardTeam[i]<<endl;
           }
           }
   ```
@@ -238,8 +238,8 @@ We assume in the code samples below you've copied them to an `impalib` subdirect
       model_graph.iterate_relaxed_graph();
 
       if (!model_graph.subtourConstraintsSatisfiedFlag && AUGM_FLAG){
-          if (model_graph.delta_S_indices_list.size() >0){
-                  vector<vector<impalib_type>> temp(model_graph.delta_S_indices_list.size(), vector<impalib_type>(N_EDGE_VARIABLES, zero_value));
+          if (model_graph.idx_delta_S.size() >0){
+                  vector<vector<impalib_type>> temp(model_graph.idx_delta_S.size(), vector<impalib_type>(N_EDGE_VARIABLES, zero_value));
                   model_graph.subtourConstraints2EdgeEcM.insert(model_graph.subtourConstraints2EdgeEcM.end(), temp.begin(), temp.end());
                   model_graph.subtourConstraints2EdgeEcDummyM  = model_graph.subtourConstraints2EdgeEcM;
           }
@@ -255,8 +255,8 @@ We assume in the code samples below you've copied them to an `impalib` subdirect
               break;
           }
 
-          if (model_graph.subtourConstraints2EdgeEcM.size() != model_graph.delta_S_indices_list.size()){
-              size_t numLists2Add = model_graph.delta_S_indices_list.size() - model_graph.subtourConstraints2EdgeEcM.size();
+          if (model_graph.subtourConstraints2EdgeEcM.size() != model_graph.idx_delta_S.size()){
+              size_t numLists2Add = model_graph.idx_delta_S.size() - model_graph.subtourConstraints2EdgeEcM.size();
               vector<vector<impalib_type>> temp(numLists2Add, vector<impalib_type>(N_EDGE_VARIABLES, zero_value));
               model_graph.subtourConstraints2EdgeEcM.insert(model_graph.subtourConstraints2EdgeEcM.end(), temp.begin(), temp.end());
               model_graph.subtourConstraints2EdgeEcDummyM  = model_graph.subtourConstraints2EdgeEcM;

--- a/include/impalib/graphical_model.hpp
+++ b/include/impalib/graphical_model.hpp
@@ -137,7 +137,7 @@ void GraphicalModelKcMwm::iterate(const int *pNON_ZERO_WEIGHT_INDICES_SIZES_PY) 
             auto stage_backward_messages = knapsack_.backward(j, max_state_department, idx_nonzero_dept, pNON_ZERO_WEIGHT_INDICES_SIZES_PY, team_weights, modelInputs_.M_team2knapsack);
 
             auto extrinsic_out = knapsack_.extrinsic_output_department_lhs(team_weights, stage_forward_messages, modelInputs_.M_team2knapsack, j, stage_backward_messages, max_state_department);
-            knapsack_.process_extrinsic_output_department(j, i, extrinsic_out, extrinsic_[j]);
+            extrinsic_[j] = knapsack_.process_extrinsic_output_department(j, i, extrinsic_out);
         }
 
         auto team2OricM_ = EqKcMwm_.team_messages_to_oric(extrinsic_, modelInputs_.RewardTeam);
@@ -301,7 +301,7 @@ void GraphicalModelTsp::initialize(const int *pEDGE_CONNECTIONS_PY, const impali
 void GraphicalModelTsp::iterate_relaxed_graph() {
     for (int i = 0; i < numIterations_; i++) {
         degree.messages_to_edge_ec(inputs_.M_edge2degree, inputs_.edges, M_degree2eq_before);
-        degree.process_filtering(i, M_degree2eq_before, M_degree2eq);
+        M_degree2eq = degree.process_filtering(i, M_degree2eq_before);
         EqTsp_.messages_to_degree_relaxed(inputs_.edges, inputs_.cost_edge_mat, M_degree2eq, inputs_.M_edge2degree);
     }
     outputs.update_extrinsic_relaxed(M_degree2eq);
@@ -457,11 +457,11 @@ void GraphicalModelTsp::iterate_augmented_graph() {
 
     for (int i = 0; i < numIterations_; i++) {
         degree.messages_to_edge_ec(inputs_.M_edge2degree, inputs_.edges, M_degree2eq_before);
-        degree.process_filtering(i, M_degree2eq_before, M_degree2eq);
+        M_degree2eq = degree.process_filtering(i, M_degree2eq_before);
 
         M_edge2subtour = EqTsp_.messages_to_subtour(idx_delta_S, inputs_.cost_edge, M_degree2eq, M_subtour2edge, inputs_.edges);
         subtour.messages_to_edge_ec(M_edge2subtour, idx_delta_S, M_subtour2edge_before);
-        subtour.process_filtering(i, M_subtour2edge_before, M_subtour2edge, idx_delta_S);
+        M_subtour2edge = subtour.process_filtering(i, M_subtour2edge_before, idx_delta_S);
         EqTsp_.messages_to_degree_augmented(M_degree2eq, M_subtour2edge, inputs_.edges, inputs_.cost_edge_mat, inputs_.M_edge2degree);
     }
 

--- a/include/impalib/graphical_model.hpp
+++ b/include/impalib/graphical_model.hpp
@@ -135,15 +135,17 @@ void GraphicalModelKcMwm::iterate(const int *pNON_ZERO_WEIGHT_INDICES_SIZES_PY) 
     for (int i = 0; i < numIterations_; i++) {
         for (int j = 0; j < numDepartments_; j++) {
             int max_state_department = modelInputs_.MaxState[j];
+            auto& idx_nonzero_dept = modelInputs_.NonZeroWeightIndices[j];
+            auto& team_weights = modelInputs_.TeamsWeightsPerDepartment[j];
 
             // Initialize forward and backward message vectors
             vector<vector<impalib_type>> stage_forward_messages(numTeams_ + 1, vector<impalib_type>(max_state_department + 1, zero_value));
             vector<vector<impalib_type>> stage_backward_messages(numTeams_ + 1, vector<impalib_type>(max_state_department + 1, zero_value));
 
-            modelKnapsacks_.forward(j, stage_forward_messages, max_state_department, modelInputs_.NonZeroWeightIndices, pNON_ZERO_WEIGHT_INDICES_SIZES_PY,
-                                    modelInputs_.TeamsWeightsPerDepartment, modelInputs_.Team2KnapsackM);
-            modelKnapsacks_.backward(j, stage_backward_messages, max_state_department, modelInputs_.NonZeroWeightIndices, pNON_ZERO_WEIGHT_INDICES_SIZES_PY,
-                                     modelInputs_.TeamsWeightsPerDepartment, modelInputs_.Team2KnapsackM);
+            modelKnapsacks_.forward(j, stage_forward_messages, max_state_department, idx_nonzero_dept, pNON_ZERO_WEIGHT_INDICES_SIZES_PY,
+                                    team_weights, modelInputs_.Team2KnapsackM);
+            modelKnapsacks_.backward(j, stage_backward_messages, max_state_department, idx_nonzero_dept, pNON_ZERO_WEIGHT_INDICES_SIZES_PY,
+                                     team_weights, modelInputs_.Team2KnapsackM);
 
             modelKnapsacks_.extrinsic_output_department_lhs(modelInputs_.TeamsWeightsPerDepartment, stage_forward_messages, modelInputs_.Team2KnapsackM, j, stage_backward_messages,
                                                             max_state_department, extrinsicOutputDepartmentDummy_);

--- a/include/impalib/graphical_model.hpp
+++ b/include/impalib/graphical_model.hpp
@@ -158,35 +158,39 @@ void GraphicalModelKcMwm::iterate(const int *pNON_ZERO_WEIGHT_INDICES_SIZES_PY) 
  */
 class GraphicalModelTsp {
    private:
-    int numNodes_;                                       ///< number of nodes of TSP
-    int numIterations_;                                  ///< number of iterations of IMPA
-    int numEdgeVariables_;                               ///< number of edges in TSP
-    bool doReset_;                                       ///< flag for resetting messages after each augmentation step
-    bool doFilter_;                                      ///< flag for filtering messages from degree/subtour constraints to edge equality constraints
-    bool doAugment_;                                     ///< whether to activate augmentation
-    vector<int> hard_decision;                           ///< hard decision vector of IMPA solution
-    impalib_type alpha_;                                 ///< filtering parameter
-    impalib_type threshold_;                             ///< threshold on hard decision
-    EqualityConstraintTsp EqTsp_;                        ///< Equality Constraint object for TSP
-    DegreeConstraint degree;                             ///< Degree Constraint object for TSP
-    SubtourEliminationConstraint subtour;                ///< Subtour constraint for TSP
-    vector<vector<impalib_type>> M_degree2eq_before;     ///< messages from degree constraint to team equality constraint before filtering
-    vector<vector<impalib_type>> M_degree2eq;            ///< messages from degree constraint to team equality constraint afters filtering
-    vector<vector<int>> selected_edges_old_;             ///< old list of selected edges (used for failure investigation)
-    vector<vector<int>> selected_edges_old_old_;         ///< another old list of selected edges (used for failure investigation)
-    int maxCount_;                                       ///< maximum count of failures
-    bool tourImpaFlag_ = false;                          ///< set flag for detected tour to be false (will be updated later)
-    vector<vector<int>> idx_delta_S;                     ///< will contain indices of edges that contribute to each subtour constraint
-    vector<vector<impalib_type>> M_subtour2edge_before;  ///< messages from subtour constraints to edge equality constraint before filtering
-    vector<vector<impalib_type>> M_edge2subtour;         ///< messages from edge equality constraint to subtour constraints
     void iterate_augmented_graph();                      ///< function of IMPA on augmented graph
     void subtour_elimination_constraints_analysis(unordered_map<int, vector<int>> &, const vector<vector<int>> &);                    ///< analysis of subtour constraints
     vector<vector<int>> hard_decision_analysis();                                                                                     ///< function for hard decision solution on IMPA solution
     bool isSubsequence(const vector<int> &, const vector<int> &);                                                                ///< function for post-processing loops_sz
     vector<vector<int>> get_closed_loops(unordered_map<int, vector<int>> &, const vector<vector<int>> &);                             ///< function for getting loops_sz
     vector<int> find_closed_loop(const unordered_map<int, vector<int>> &, int, int, unordered_set<int>, vector<int>);  ///< function for finding loops_sz
+
+    int numNodes_;                                       ///< number of nodes of TSP
+    int numIterations_;                                  ///< number of iterations of IMPA
+    int numEdgeVariables_;                               ///< number of edges in TSP
+    bool doReset_;                                       ///< flag for resetting messages after each augmentation step
+    bool doFilter_;                                      ///< flag for filtering messages from degree/subtour constraints to edge equality constraints
+    bool doAugment_;                                     ///< whether to activate augmentation
+
+    impalib_type alpha_;                                 ///< filtering parameter
+
+    impalib_type threshold_;                             ///< threshold on hard decision
+    EqualityConstraintTsp EqTsp_;                        ///< Equality Constraint object for TSP
+    DegreeConstraint degree;                             ///< Degree Constraint object for TSP
+
+    SubtourEliminationConstraint subtour;                ///< Subtour constraint for TSP
+    vector<vector<impalib_type>> M_degree2eq_before;     ///< messages from degree constraint to team equality constraint before filtering
+    vector<vector<impalib_type>> M_degree2eq;            ///< messages from degree constraint to team equality constraint afters filtering
+    int maxCount_;                                       ///< maximum count of failures
+    bool tourImpaFlag_ = false;                          ///< set flag for detected tour to be false (will be updated later)
+    vector<vector<int>> idx_delta_S;                     ///< will contain indices of edges that contribute to each subtour constraint
+    vector<vector<impalib_type>> M_subtour2edge_before;  ///< messages from subtour constraints to edge equality constraint before filtering
+    vector<vector<impalib_type>> M_edge2subtour;         ///< messages from edge equality constraint to subtour constraints
     InputsTsp inputs_;                                                                                                                ///< Graphical Model Input object
     vector<vector<int>> selectedEdges_;                                                                                               ///< activated edges of IMPA
+
+    vector<vector<int>> selected_edges_old_;             ///< old list of selected edges (used for failure investigation)
+    vector<vector<int>> selected_edges_old_old_;         ///< another old list of selected edges (used for failure investigation)
     int numAugmentations_ = 0;                                                                                                        ///< number of performed augmentations in IMPA
     int noConsClosedLoopsCount_ = 0;              ///< count for failure case (no consecutive loop detection and no tour)
     int n_osc = 0;                                ///< count for failure case (oscillation in the solution)
@@ -535,7 +539,7 @@ void GraphicalModelTsp::iterate_augmented_graph() {
  */
 vector<vector<int>> GraphicalModelTsp::hard_decision_analysis() {
     vector<vector<int>> selected;
-    hard_decision.resize(numEdgeVariables_);
+    vector<int> hard_decision(numEdgeVariables_);
     fill(hard_decision.begin(), hard_decision.begin() + numEdgeVariables_, numeric_limits<int>::max());
 
     // Apply threshold to intrinsic output to determine hard decision

--- a/include/impalib/graphical_model.hpp
+++ b/include/impalib/graphical_model.hpp
@@ -36,9 +36,9 @@ class GraphicalModelKcMwm {
    public:
     OutputsKcMwm outputs; ///< Graphical model outputs objects
     InputsKcMwm modelInputs_; ///< Graphical model inputs objects
-    void initialize(const impalib_type *, impalib_type *, const int *, const int *, const int *, const impalib_type *, const int *); ///< initialize graphical model
+    void initialize(const impalib_type *, const impalib_type *, const int *, const int *, const int *, const impalib_type *, const int *); ///< initialize graphical model
     void iterate(const int *); ///< iterate over graphical model
-    GraphicalModelKcMwm(const int N_DEPARTMENTS, const int N_TEAMS, const int N_PROJECTS, const int MAX_SIZE_NON_ZERO_WEIGHTS, const int N_ITERATIONS, const bool FILT_FLAG, const impalib_type ALPHA); ///< constructor
+    GraphicalModelKcMwm(int N_DEPARTMENTS, int N_TEAMS, int N_PROJECTS, int MAX_SIZE_NON_ZERO_WEIGHTS, int N_ITERATIONS, bool FILT_FLAG, impalib_type ALPHA); ///< constructor
 };
 
 /**
@@ -110,7 +110,7 @@ GraphicalModelKcMwm::GraphicalModelKcMwm(const int N_DEPARTMENTS, const int N_TE
  *
  */
 
-void GraphicalModelKcMwm::initialize(const impalib_type *pREWARD_TEAM_PY, impalib_type *pTransition_model_py, const int *pITEMS_WEIGHTS_PER_DEPARTMENT_PY, const int *pNON_ZERO_WEIGHT_INDICES_SIZES_PY,
+void GraphicalModelKcMwm::initialize(const impalib_type *pREWARD_TEAM_PY, const impalib_type *pTransition_model_py, const int *pITEMS_WEIGHTS_PER_DEPARTMENT_PY, const int *pNON_ZERO_WEIGHT_INDICES_SIZES_PY,
                                      const int *p_NON_ZERO_WEIGHT_INDICES_PY, const impalib_type *pREWARD_PROJECT_PY, const int *pMAX_STATE_PY) {
     /// calls a method process_inputs() on an object modelInputs_, passing
     /// several pointers to Python objects as arguments
@@ -189,11 +189,11 @@ class GraphicalModelTsp {
     vector<vector<impalib_type>> subtourConstraints2EdgeEcDummyM_; ///< messages from subtour constraints to edge equality constraint before filtering
     vector<vector<impalib_type>> edgeEc2SubtourConstraintsM_; ///< messages from edge equality constraint to subtour constraints
     void iterate_augmented_graph(); ///< function of IMPA on augmented graph
-    void subtour_elimination_constraints_analysis(unordered_map<int, vector<int>> &, vector<vector<int>> &); ///< analysis of subtour constraints
+    void subtour_elimination_constraints_analysis(unordered_map<int, vector<int>> &, const vector<vector<int>> &); ///< analysis of subtour constraints
     void hard_decision_analysis(vector<vector<int>> &); ///< function for hard decision solution on IMPA solution
     bool isSubsequence(const vector<int> &, const vector<int> &, int); ///< function for post-processing loops
-    vector<vector<int>> get_closed_loops(unordered_map<int, vector<int>> &, vector<vector<int>> &); ///< function for getting loops
-    vector<int> find_closed_loop(unordered_map<int, vector<int>> &, int, int, unordered_set<int>, vector<int>, vector<int> &); ///< function for finding loops
+    vector<vector<int>> get_closed_loops(unordered_map<int, vector<int>> &, const vector<vector<int>> &); ///< function for getting loops
+    vector<int> find_closed_loop(const unordered_map<int, vector<int>> &, int, int, unordered_set<int>, vector<int>, vector<int> &); ///< function for finding loops
     InputsTsp modelInputs_; ///< Graphical Model Input object
     vector<vector<int>> selectedEdges_; ///< activated edges of IMPA
     int numAugmentations_ = 0; ///< number of performed augmentations in IMPA
@@ -212,9 +212,9 @@ class GraphicalModelTsp {
    public:
     bool subtourConstraintsSatisfiedFlag = false; ///< initially set this flag for satisfied subtour constraints to false
     OutputsTsp outputs; ///< TSP graphical model outputs object
-    void initialize(const int *, const impalib_type *, const impalib_type *, impalib_type *, const impalib_type *); ///< initialize graphical model
+    void initialize(const int *, const impalib_type *, const impalib_type *, const impalib_type *, const impalib_type *); ///< initialize graphical model
     void iterate_relaxed_graph(); ///< iterate over relaxed graphical model
-    void perform_augmentation(const int); ///< perform augmentation on graphical model
+    void perform_augmentation(int); ///< perform augmentation on graphical model
     void process_ouputs(impalib_type *, int *, int *, int *, impalib_type *, bool *, bool *, bool *, int *, int *, int *, int *); ///< process outputs of Graphical Model
     GraphicalModelTsp(const int NUM_ITERATIONS, const int NUM_NODES, const int NUM_EDGE_VARIABLES, const bool AUGMENTATION_FLAG, const bool RESET_FLAG, const bool FILTERING_FLAG,
                       const impalib_type ALPHA, const impalib_type THRESHOLD, const int MAX_COUNT); ///< Constructor
@@ -296,7 +296,7 @@ GraphicalModelTsp::GraphicalModelTsp(const int NUM_ITERATIONS, const int NUM_NOD
  *
  */
 
-void GraphicalModelTsp::initialize(const int *pEDGE_CONNECTIONS_PY, const impalib_type *pCOST_EDGE_VARIABLE_PY, const impalib_type *pCOST_MATRIX_PY, impalib_type *pEdge_ec_to_degree_constraint_m_py,
+void GraphicalModelTsp::initialize(const int *pEDGE_CONNECTIONS_PY, const impalib_type *pCOST_EDGE_VARIABLE_PY, const impalib_type *pCOST_MATRIX_PY, const impalib_type *pEdge_ec_to_degree_constraint_m_py,
                                    const impalib_type *pEDGE_DEGREE_CONSTRAINT_COST_PY) {
     // Populate model data
     modelInputs_.process_inputs(pEDGE_CONNECTIONS_PY, pCOST_EDGE_VARIABLE_PY, pCOST_MATRIX_PY, pEdge_ec_to_degree_constraint_m_py, pEDGE_DEGREE_CONSTRAINT_COST_PY);
@@ -612,7 +612,7 @@ void GraphicalModelTsp::hard_decision_analysis(vector<vector<int>> &rSelectedEdg
  *
  */
 
-void GraphicalModelTsp::subtour_elimination_constraints_analysis(unordered_map<int, vector<int>> &rGraph, vector<vector<int>> &rSelectedEdges) {
+void GraphicalModelTsp::subtour_elimination_constraints_analysis(unordered_map<int, vector<int>> &rGraph, const vector<vector<int>> &rSelectedEdges) {
     closedPathsSize_.clear();  // just store it at the end if applicable
 
     // Get closed loops from the graph
@@ -704,7 +704,7 @@ void GraphicalModelTsp::subtour_elimination_constraints_analysis(unordered_map<i
  * @return new_loops_list: list of detected loops in rGraph
  *
  */
-vector<vector<int>> GraphicalModelTsp::get_closed_loops(unordered_map<int, vector<int>> &rGraph, vector<vector<int>> &rSelectedEgdes) {
+vector<vector<int>> GraphicalModelTsp::get_closed_loops(unordered_map<int, vector<int>> &rGraph, const vector<vector<int>> &rSelectedEgdes) {
     // Update the graph based on selected edges
     for (const auto &connection : rSelectedEgdes) {
         if (rGraph.find(connection[0]) != rGraph.end()) {
@@ -819,7 +819,7 @@ bool GraphicalModelTsp::isSubsequence(const vector<int> &seq, const vector<int> 
  * between the nodes (if a tour is found, )
  *
  */
-vector<int> GraphicalModelTsp::find_closed_loop(unordered_map<int, vector<int>> &rGraph, int start_node, int current, unordered_set<int> visited, vector<int> path, vector<int> &visited_nodes) {
+vector<int> GraphicalModelTsp::find_closed_loop(const unordered_map<int, vector<int>> &rGraph, int start_node, int current, unordered_set<int> visited, vector<int> path, vector<int> &visited_nodes) {
     visited.insert(current);
     path.push_back(current);
 

--- a/include/impalib/graphical_model.hpp
+++ b/include/impalib/graphical_model.hpp
@@ -85,36 +85,16 @@ GraphicalModelKcMwm::GraphicalModelKcMwm(const int N_DEPARTMENTS, const int N_TE
       maxSizeNonZeroWeights_(MAX_SIZE_NON_ZERO_WEIGHTS),
       numIterations_(N_ITERATIONS),
       filteringFlag_(FILT_FLAG),
-      alpha_(ALPHA) {
-    /// initializes and prepares data structures for mapping relationships
-    /// between teams, projects, and constraints
-    oric2PackageM_.resize(numTeams_);
-    team2OricM_.resize(numTeams_);
-    fill(oric2PackageM_.begin(), oric2PackageM_.begin() + numTeams_, zero_value);
-    fill(team2OricM_.begin(), team2OricM_.begin() + numTeams_, zero_value);
-
-    eqConstraint2OricM_.reserve(numProjects_);
-    oric2EqConstraintM_.reserve(numProjects_);
-    eqConstraint2ProjectM_.reserve(numProjects_);
-    project2EqConstraintM_.reserve(numProjects_);
-
-    for (int i = 0; i < numProjects_; i++) {
-        eqConstraint2OricM_.push_back(vector<impalib_type>(numTeams_, zero_value));
-        oric2EqConstraintM_.push_back(vector<impalib_type>(numTeams_, zero_value));
-        eqConstraint2ProjectM_.push_back(vector<impalib_type>(numTeams_, zero_value));
-        project2EqConstraintM_.push_back(vector<impalib_type>(numTeams_, zero_value));
-    }
-
-    /// initializes and prepares data structures for messages from departments
-    extrinsicOutputDepartment_.reserve(numDepartments_);
-    extrinsicOutputDepartmentDummy_.reserve(numDepartments_);
-
-    /// initializes and populates nested vectors for mapping relationships
-    /// between departments and teams
-    for (int i = 0; i < numDepartments_; i++) {
-        extrinsicOutputDepartment_.push_back(vector<impalib_type>(numTeams_, zero_value));
-        extrinsicOutputDepartmentDummy_.push_back(vector<impalib_type>(numTeams_, zero_value));
-    }
+      alpha_(ALPHA),
+      oric2PackageM_(numTeams_, 0),
+      team2OricM_(numTeams_, 0),
+      eqConstraint2OricM_(numProjects_, vector<impalib_type>(numTeams_, 0)),
+      oric2EqConstraintM_(numProjects_, vector<impalib_type>(numTeams_, 0)),
+      eqConstraint2ProjectM_(numProjects_, vector<impalib_type>(numTeams_, 0)),
+      project2EqConstraintM_(numProjects_, vector<impalib_type>(numTeams_, 0)),
+      extrinsicOutputDepartmentDummy_(numDepartments_, vector<impalib_type>(numTeams_, 0)),
+      extrinsicOutputDepartment_(numDepartments_, vector<impalib_type>(numTeams_, 0))
+{
 };
 
 /**
@@ -217,17 +197,17 @@ class GraphicalModelTsp {
     vector<int> find_closed_loop(unordered_map<int, vector<int>> &, int, int, unordered_set<int>, vector<int>, vector<int> &); ///< function for finding loops
     InputsTsp modelInputs_; ///< Graphical Model Input object
     vector<vector<int>> selectedEdges_; ///< activated edges of IMPA
-    int numAugmentations_; ///< number of performed augmentations in IMPA
-    int noConsClosedLoopsCount_; ///< count for failure case (no consecutive loop detection and no tour)
-    int solOscCount_; ///< count for failure case (oscillation in the solution)
-    bool noConsClosedLoopsCountExcFlag_; ///< flag for failure case (no consecutive loop detection and no tour)
-    int noImprovSolCount_; ///< count for failure case (no solution improvement)
-    bool noImprovSolCountExcFlag_; ///< flag for failure case (no solution improvement)
-    bool solOscCountExcFlag_; ///< flag for failure case (oscillation in the solution)
+    int numAugmentations_ = 0; ///< number of performed augmentations in IMPA
+    int noConsClosedLoopsCount_ = 0; ///< count for failure case (no consecutive loop detection and no tour)
+    int solOscCount_ = 0; ///< count for failure case (oscillation in the solution)
+    bool noConsClosedLoopsCountExcFlag_ = false; ///< flag for failure case (no consecutive loop detection and no tour)
+    int noImprovSolCount_ = 0; ///< count for failure case (no solution improvement)
+    bool noImprovSolCountExcFlag_ = false; ///< flag for failure case (no solution improvement)
+    bool solOscCountExcFlag_ = false; ///< flag for failure case (oscillation in the solution)
     vector<int> tourImpa_; ///< list of nodes of tour (if detected)
     vector<vector<int>> subtourPaths_; ///< list of detected subtours (if detected)
     vector<int> closedPathsSize_; ///< list of sizes of loops
-    impalib_type costImpa_; ///< cost of IMPA solution
+    impalib_type costImpa_ = zero_value; ///< cost of IMPA solution
     vector<vector<impalib_type>> subtourConstraints2EdgeEcM_; ///< messages from subtour constraints to edge equality constraint
 
    public:
@@ -292,25 +272,10 @@ GraphicalModelTsp::GraphicalModelTsp(const int NUM_ITERATIONS, const int NUM_NOD
       resetFlag_(RESET_FLAG),
       numEdgeVariables_(NUM_EDGE_VARIABLES),
       threshold_(THRESHOLD),
-      maxCount_(MAX_COUNT) {
-    DegreeConstraint2EqConstraintDummyM_.reserve(numEdgeVariables_);
-    DegreeConstraint2EqConstraintM_.reserve(numEdgeVariables_);
-
-    // Populate degree constraint to equality constraint messages
-    for (int i = 0; i < numEdgeVariables_; i++) {
-        DegreeConstraint2EqConstraintDummyM_.push_back(vector<impalib_type>(numNodes_, zero_value));
-        DegreeConstraint2EqConstraintM_.push_back(vector<impalib_type>(numNodes_, zero_value));
-    }
-
-    numAugmentations_ = 0;
-    costImpa_ = zero_value;
-    noConsClosedLoopsCount_ = 0;
-    noImprovSolCount_ = 0;
-    solOscCount_ = 0;
-
-    noConsClosedLoopsCountExcFlag_ = false;
-    noImprovSolCountExcFlag_ = false;
-    solOscCountExcFlag_ = false;
+      maxCount_(MAX_COUNT),
+      DegreeConstraint2EqConstraintDummyM_(numEdgeVariables_, vector<impalib_type>(numNodes_, 0)),
+      DegreeConstraint2EqConstraintM_(numEdgeVariables_, vector<impalib_type>(numNodes_, 0))
+{
 };
 
 /**

--- a/include/impalib/graphical_model.hpp
+++ b/include/impalib/graphical_model.hpp
@@ -53,24 +53,9 @@ class GraphicalModelKcMwm {
  * @param[in] N_ITERATIONS: number of iterations for running IMPA
  * @param[in] FILT_FLAG: filtering on or off
  * @param[in] ALPHA: filtering parameter value (between 0 and 1)
- * @param[out] modelInputs_: object of type InputsKcMwm: inputs of graphical
- * model
- * @param[out] outputs: object of type OutputsKcMwm: outputs of graphical model
- * @param[out] projectIneqConstraint_: object of type InequalityConstraint:
- * object associated with inequality constraint operations
- * @param[out] modelEqConstraint_: object of type EqualityConstraintKcMwm:
- * object associated with equality constraint operations
- * @param[out] numProjects_: N_PROJECTS
- * @param[out] numTeams_: N_TEAMS
- * @param[out] numDepartments_: N_DEPARTMENTS
- * @param[out] maxSizeNonZeroWeights_: MAX_SIZE_NON_ZERO_WEIGHTS
- * @param[out] numIterations_: N_ITERATIONS
- * @param[out] filteringFlag_: FILT_FLAG
- * @param[out] alpha_: ALPHA
  *
  */
-
-GraphicalModelKcMwm::GraphicalModelKcMwm(const int N_DEPARTMENTS, const int N_TEAMS, const int N_PROJECTS, const int MAX_SIZE_NON_ZERO_WEIGHTS, const int N_ITERATIONS, const bool FILT_FLAG,
+inline GraphicalModelKcMwm::GraphicalModelKcMwm(const int N_DEPARTMENTS, const int N_TEAMS, const int N_PROJECTS, const int MAX_SIZE_NON_ZERO_WEIGHTS, const int N_ITERATIONS, const bool FILT_FLAG,
                                          const impalib_type ALPHA)
     : modelInputs_(N_DEPARTMENTS, N_TEAMS, N_PROJECTS, MAX_SIZE_NON_ZERO_WEIGHTS),
       outputs(N_DEPARTMENTS, N_TEAMS, N_PROJECTS),
@@ -107,8 +92,7 @@ GraphicalModelKcMwm::GraphicalModelKcMwm(const int N_DEPARTMENTS, const int N_TE
  * @param[in] pMAX_STATE_PY: contains maximum capacity of departments
  *
  */
-
-void GraphicalModelKcMwm::initialize(const impalib_type *pREWARD_TEAM_PY, const impalib_type *pTransition_model_py, const int *pITEMS_WEIGHTS_PER_DEPARTMENT_PY,
+inline void GraphicalModelKcMwm::initialize(const impalib_type *pREWARD_TEAM_PY, const impalib_type *pTransition_model_py, const int *pITEMS_WEIGHTS_PER_DEPARTMENT_PY,
                                      const int *pNON_ZERO_WEIGHT_INDICES_SIZES_PY, const int *p_NON_ZERO_WEIGHT_INDICES_PY, const impalib_type *pREWARD_PROJECT_PY, const int *pMAX_STATE_PY) {
     /// calls a method process_inputs() on an object inputs_, passing
     /// several pointers to Python objects as arguments
@@ -124,8 +108,7 @@ void GraphicalModelKcMwm::initialize(const impalib_type *pREWARD_TEAM_PY, const 
  * between teams and departments
  *
  */
-
-void GraphicalModelKcMwm::iterate(const int *pNON_ZERO_WEIGHT_INDICES_SIZES_PY) {
+inline void GraphicalModelKcMwm::iterate(const int *pNON_ZERO_WEIGHT_INDICES_SIZES_PY) {
     vector<impalib_type> oric2PackageM_(numTeams_, 0);
     for (int i = 0; i < numIterations_; i++) {
         for (int j = 0; j < numDepartments_; j++) {
@@ -240,30 +223,9 @@ class GraphicalModelTsp {
  * @param[in] ALPHA: filtering parameter value (between 0 and 1)
  * @param[in] THRESHOLD: threshold for hard decision on intrinsic messages
  * @param[in] MAX_COUNT: maximum count of failure cases before exiting the code
- * @param[out] modelDegreeConstraint_: object of type DegreeConstraint: object
- * associated with degree constraint operations
- * @param[out] modelEqConstraint_: object of type EqualityConstraintTsp: object
- * associated with equality constraint operations
- * @param[out] modelSubtourEliminationConstraint_: object of type
- * SubtourEliminationConstraint: object associated with subtour elimination
- * constraint operations
- * @param[out] modelInputs_: object of type InputsTsp: object associated with
- * inputs of tsp
- * @param[out] outputs: object of type OutputsTsp: object associated with
- * outputs of tsp
- * @param[out] numIterations_: NUM_ITERATIONS
- * @param[out] filteringFlag_: FILTERING_FLAG
- * @param[out] alpha_: ALPHA
- * @param[out] numNodes_: NUM_NODES
- * @param[out] augmentationFlag_: AUGMENTATION_FLAG
- * @param[out] resetFlag_: RESET_FLAG
- * @param[out] numEdgeVariables_: NUM_EDGE_VARIABLES
- * @param[out] threshold_: THRESHOLD
- * @param[out] maxCount_: MAX_COUNT
  *
  */
-
-GraphicalModelTsp::GraphicalModelTsp(const int NUM_ITERATIONS, const int NUM_NODES, const int NUM_EDGE_VARIABLES, const bool AUGMENTATION_FLAG, const bool RESET_FLAG, const bool FILTERING_FLAG,
+inline GraphicalModelTsp::GraphicalModelTsp(const int NUM_ITERATIONS, const int NUM_NODES, const int NUM_EDGE_VARIABLES, const bool AUGMENTATION_FLAG, const bool RESET_FLAG, const bool FILTERING_FLAG,
                                      const impalib_type ALPHA, const impalib_type THRESHOLD, const int MAX_COUNT)
     : degree(NUM_NODES, NUM_EDGE_VARIABLES, FILTERING_FLAG, ALPHA),
       EqTsp_(NUM_NODES, NUM_EDGE_VARIABLES, FILTERING_FLAG, ALPHA),
@@ -299,8 +261,7 @@ GraphicalModelTsp::GraphicalModelTsp(const int NUM_ITERATIONS, const int NUM_NOD
  * computations in the IMPA
  *
  */
-
-void GraphicalModelTsp::initialize(const int *pEDGE_CONNECTIONS_PY, const impalib_type *pCOST_EDGE_VARIABLE_PY, const impalib_type *pCOST_MATRIX_PY,
+inline void GraphicalModelTsp::initialize(const int *pEDGE_CONNECTIONS_PY, const impalib_type *pCOST_EDGE_VARIABLE_PY, const impalib_type *pCOST_MATRIX_PY,
                                    const impalib_type *pEdge_ec_to_degree_constraint_m_py, const impalib_type *pEDGE_DEGREE_CONSTRAINT_COST_PY) {
     // Populate model data
     inputs_.process_inputs(pEDGE_CONNECTIONS_PY, pCOST_EDGE_VARIABLE_PY, pCOST_MATRIX_PY, pEdge_ec_to_degree_constraint_m_py, pEDGE_DEGREE_CONSTRAINT_COST_PY);
@@ -343,8 +304,7 @@ SubtourAnalysisResult GraphicalModelTsp::iterate_relaxed_graph() {
  * @param[in] MAX_AUGM_COUNT: maximum number of augmentation steps
  *
  */
-
-void GraphicalModelTsp::perform_augmentation(const int MAX_AUGM_COUNT) {
+inline void GraphicalModelTsp::perform_augmentation(const int MAX_AUGM_COUNT) {
     // Add empty vectors to subtour constraints if needed
     if (idx_delta_S.size() > 0) {
         vector<vector<impalib_type>> temp(idx_delta_S.size(), vector<impalib_type>(numEdgeVariables_, zero_value));
@@ -409,8 +369,7 @@ void GraphicalModelTsp::perform_augmentation(const int MAX_AUGM_COUNT) {
  * @param[out] pSubtour_paths_size: number of subtour paths
  *
  */
-
-void GraphicalModelTsp::process_outputs(impalib_type *pExtrinsic_output_edge_ec, int *pNum_augmentations, int *pNum_added_constraints, int *pTour_impa, impalib_type *pCost_impa,
+inline void GraphicalModelTsp::process_outputs(impalib_type *pExtrinsic_output_edge_ec, int *pNum_augmentations, int *pNum_added_constraints, int *pTour_impa, impalib_type *pCost_impa,
                                        bool *pNo_improv_sol_count_exc_flag, bool *pNo_cons_loops_count_exc_flag, bool *pSol_osc_count_exc_flag, int *pSelected_edges, int *pSelected_edges_size,
                                        int *pSubtour_paths, int *pSubtour_paths_size) {
     // Copy extrinsic_ output for edge equality constraints
@@ -452,7 +411,7 @@ void GraphicalModelTsp::process_outputs(impalib_type *pExtrinsic_output_edge_ec,
  *
  */
  // NOTE:
-SubtourAnalysisResult GraphicalModelTsp::iterate_augmented_graph() {
+inline SubtourAnalysisResult GraphicalModelTsp::iterate_augmented_graph() {
     // Reset messages if flag is set
     if (doReset_) {
         for (size_t i = 0; i < inputs_.edges.size(); i++) {
@@ -561,7 +520,7 @@ SubtourAnalysisResult GraphicalModelTsp::iterate_augmented_graph() {
 /**
  * This will get the hard decision on edges by investigating the sign
  * intrinsic
- * @param[out] rSelectedEdges: activated edges after running IMPA
+ * @returns: activated edges after running IMPA
  *
  */
 vector<vector<int>> GraphicalModelTsp::hard_decision_analysis() {
@@ -626,13 +585,12 @@ vector<vector<int>> GraphicalModelTsp::hard_decision_analysis() {
  * @param[in] rSelectedEdges: activated edges in the graphical model
  * @param[out] rGraph: graphical model of activated egdes. Defines connections
  * between nodes
- * **/
-
-// NOTE: this resets loops_sz and subtours
-// sets various failure/satisfy flags
-// resets tour
-
-SubtourAnalysisResult GraphicalModelTsp::subtour_elimination_constraints_analysis(unordered_map<int, vector<int>> &rGraph, const vector<vector<int>> &rSelectedEdges) {
+ *
+ * NOTE: this resets loops_sz and subtours
+ * sets various failure/satisfy flags
+ * resets tour
+**/
+inline SubtourAnalysisResult GraphicalModelTsp::subtour_elimination_constraints_analysis(unordered_map<int, vector<int>> &rGraph, const vector<vector<int>> &rSelectedEdges) {
     vector<vector<int>> loops_list = get_closed_loops(rGraph, rSelectedEdges);
     vector<int> loops_sz;
     auto subtours = loops_list;
@@ -724,13 +682,13 @@ SubtourAnalysisResult GraphicalModelTsp::subtour_elimination_constraints_analysi
 /**
  * Get closed loops_sz. Function for building the graphical model of activated
  * edges and obtain loops_sz
- * @param[in] rSelectedEdges: activated edges in the graphical model
+ * @param[in] edges: activated edges in the graphical model
  * @param[out] G: graphical model of activated egdes. Defines connections
  * between nodes. Will be used for detecting of subtours
  * @return new_loops_list: list of detected loops_sz in G
  *
  */
-vector<vector<int>> GraphicalModelTsp::get_closed_loops(unordered_map<int, vector<int>> &G, const vector<vector<int>> &edges) {
+inline vector<vector<int>> GraphicalModelTsp::get_closed_loops(unordered_map<int, vector<int>> &G, const vector<vector<int>> &edges) {
     // Update the graph based on selected edges
     for (const auto &connection : edges) {
         if (G.find(connection[0]) != G.end()) {
@@ -807,12 +765,10 @@ vector<vector<int>> GraphicalModelTsp::get_closed_loops(unordered_map<int, vecto
  * corresponding positions
  * @param[in] seq: subsequence
  * @param[in] subseq: subsequence
- * @param[in] j: index in loops_list. For printing purposes, if needed. It is
- * not used in the code.
- * @return false or true if subseq is a isSubsequence of seq
+ * @returns false or true if subseq is a isSubsequence of seq
  *
  */
-bool GraphicalModelTsp::isSubsequence(const vector<int> &seq, const vector<int> &subseq) {
+inline bool GraphicalModelTsp::isSubsequence(const vector<int> &seq, const vector<int> &subseq) {
     for (int i = 0; i < static_cast<int>(seq.size() - subseq.size()); ++i) {
         if (equal(seq.begin() + i, seq.begin() + i + static_cast<int>(subseq.size()), subseq.begin())) {
             return true;
@@ -829,13 +785,13 @@ bool GraphicalModelTsp::isSubsequence(const vector<int> &seq, const vector<int> 
  * neighboring nodes
  * @param[in] start_node: node the path is starting from
  * @param[in] current: current node under investigation in the path
- * @param[out] visited_all: visited_all nodes while constructing the path
- * @param[out] path: current detected path, which will be augmented
- * @return new_path or empty vector if no path is found. new_path is a path
- * between the nodes (if a tour is found, )
+ * @param[in] visited_all: visited_all nodes while constructing the path
+ * @returns current detected path, which will be augmented
+ *   new_path or empty vector if no path is found. new_path is a path
+ *   between the nodes (if a tour is found, )
  *
  */
-vector<int> GraphicalModelTsp::find_closed_loop(const unordered_map<int, vector<int>> &G, int start_node, int current, unordered_set<int> visited_all, vector<int> path) {
+inline vector<int> GraphicalModelTsp::find_closed_loop(const unordered_map<int, vector<int>> &G, int start_node, int current, unordered_set<int> visited_all, vector<int> path) {
     visited_all.insert(current);
     path.push_back(current);
 

--- a/include/impalib/graphical_model.hpp
+++ b/include/impalib/graphical_model.hpp
@@ -176,10 +176,10 @@ void GraphicalModelKcMwm::iterate(const int *pNON_ZERO_WEIGHT_INDICES_SIZES_PY) 
         modelEqConstraint_.project_eq_constraint_to_oric_update(project2EqConstraintM_, eqConstraint2OricM_, modelInputs_.RewardProject);
 
         modelOric_.oric_to_team_update(eqConstraint2OricM_, oric2PackageM_);
-        outputs.intrinsic_out_mwm_update(oric2EqConstraintM_, project2EqConstraintM_, modelInputs_.RewardProject);
+        outputs.update_intrinsic(oric2EqConstraintM_, project2EqConstraintM_, modelInputs_.RewardProject);
         modelKnapsacks_.team_to_knapsack_update(modelInputs_.NonZeroWeightIndices, modelInputs_.Team2KnapsackM, modelInputs_.RewardTeam, extrinsicOutputDepartment_, oric2PackageM_);
     }
-    outputs.extrinsic_output_team_update(extrinsicOutputDepartment_, oric2PackageM_);
+    outputs.update_extrinsic(extrinsicOutputDepartment_, oric2PackageM_);
 }
 
 /**
@@ -352,8 +352,8 @@ void GraphicalModelTsp::iterate_relaxed_graph() {
         modelEqConstraint_.edge_ec_to_degree_constraint_relaxed_graph_update(modelInputs_.EdgeConnections, modelInputs_.EdgeDegreeConstraintCost, DegreeConstraint2EqConstraintM_,
                                                                              modelInputs_.EdgeEc2DegreeConstraintM);
     }
-    outputs.extrinsic_output_edge_ec_relaxed_graph_update(DegreeConstraint2EqConstraintM_);
-    outputs.intrinsic_output_edge_ec_update(modelInputs_.CostEdgeVariable);
+    outputs.update_extrinsic_relaxed(DegreeConstraint2EqConstraintM_);
+    outputs.update_intrinsic(modelInputs_.CostEdgeVariable);
 
     // Perform hard decision analysis to select edges
     vector<vector<int>> selected_edges;
@@ -532,8 +532,8 @@ void GraphicalModelTsp::iterate_augmented_graph() {
         exit(0);
     }
 
-    outputs.extrinsic_output_edge_ec_augmented_graph_update(DegreeConstraint2EqConstraintM_, subtourConstraints2EdgeEcM_);
-    outputs.intrinsic_output_edge_ec_update(modelInputs_.CostEdgeVariable);
+    outputs.update_extrinsic_augmented(DegreeConstraint2EqConstraintM_, subtourConstraints2EdgeEcM_);
+    outputs.update_intrinsic(modelInputs_.CostEdgeVariable);
 
     selectedEdges_.clear();
     vector<vector<int>> selected_edges;

--- a/include/impalib/graphical_model.hpp
+++ b/include/impalib/graphical_model.hpp
@@ -206,8 +206,8 @@ class GraphicalModelTsp {
     SubtourAnalysisResult iterate_relaxed_graph();                                                                                          ///< iterate over relaxed graphical model
     void perform_augmentation(int);                                                                                        ///< perform augmentation on graphical model
     void process_outputs(impalib_type *, int *, int *, int *, impalib_type *, bool *, bool *, bool *, int *, int *, int *, int *);  ///< process outputs of Graphical Model
-    GraphicalModelTsp(const int NUM_ITERATIONS, const int NUM_NODES, const int NUM_EDGE_VARIABLES, const bool AUGMENTATION_FLAG, const bool RESET_FLAG, const bool FILTERING_FLAG,
-                      const impalib_type ALPHA, const impalib_type THRESHOLD, const int MAX_COUNT);  ///< Constructor
+    GraphicalModelTsp(int NUM_ITERATIONS, int NUM_NODES, int NUM_EDGE_VARIABLES, bool AUGMENTATION_FLAG, bool RESET_FLAG, bool FILTERING_FLAG,
+                      impalib_type ALPHA, impalib_type THRESHOLD, int MAX_COUNT);  ///< Constructor
 };
 
 /**

--- a/include/impalib/input_output.hpp
+++ b/include/impalib/input_output.hpp
@@ -148,15 +148,9 @@ void InputsKcMwm::process_inputs(const impalib_type *pREWARD_TEAM_PY, impalib_ty
  */
 
 OutputsKcMwm::OutputsKcMwm(const int N_DEPARTMENTS, const int N_TEAMS, const int N_PROJECTS)
-    : numDepartments_(N_DEPARTMENTS), numTeams_(N_TEAMS), numProjects_(N_PROJECTS)
+    : numDepartments_(N_DEPARTMENTS), numTeams_(N_TEAMS), numProjects_(N_PROJECTS),
+      ExtrinsicOutputTeam(numTeams_, 0), IntrinsicOutMwm(numProjects_ * numTeams_, 0)
 {
-    ExtrinsicOutputTeam.reserve(numTeams_);
-    ExtrinsicOutputTeam.resize(numTeams_);
-    fill(ExtrinsicOutputTeam.begin(), ExtrinsicOutputTeam.begin() + numTeams_, zero_value);
-
-    IntrinsicOutMwm.reserve(numProjects_ * numTeams_);
-    IntrinsicOutMwm.resize(numProjects_ * numTeams_);
-    fill(IntrinsicOutMwm.begin(), IntrinsicOutMwm.begin() + numProjects_ * numTeams_, zero_value);
 };
 
 /**

--- a/include/impalib/input_output.hpp
+++ b/include/impalib/input_output.hpp
@@ -77,14 +77,14 @@ InputsKcMwm::InputsKcMwm(const int N_DEPARTMENTS, const int N_TEAMS, const int N
     Team2KnapsackM.reserve(numDepartments_);
 
     // Initialize Team2KnapsackM and TeamsWeightsPerDepartment vectors
-    for (int department_index = 0; department_index < numDepartments_; department_index++)
+    for (int i = 0; i < numDepartments_; i++)
     {
         Team2KnapsackM.push_back(vector<impalib_type>(numTeams_, zero_value));
         TeamsWeightsPerDepartment.push_back(vector<int>(numTeams_, 0));
     }
 
     // Initialize RewardProject vector
-    for (int project_index = 0; project_index < numProjects_; project_index++)
+    for (int i = 0; i < numProjects_; i++)
     {
         RewardProject.push_back(vector<impalib_type>(numTeams_, zero_value));
     }
@@ -113,25 +113,25 @@ void InputsKcMwm::process_inputs(const impalib_type *pREWARD_TEAM_PY, impalib_ty
     copy(pREWARD_TEAM_PY, pREWARD_TEAM_PY + numTeams_, back_inserter(RewardTeam));
     copy(pMAX_STATE_PY, pMAX_STATE_PY + numDepartments_, back_inserter(MaxState));
 
-    for (int department_index = 0; department_index < numDepartments_; department_index++)
+    for (int i = 0; i < numDepartments_; i++)
     {   
         // Populate NonZeroWeightIndices for the department
-        NonZeroWeightIndices.push_back(vector<int>(pNON_ZERO_WEIGHT_INDICES_SIZES_PY[department_index], 0));
-        copy(pTransition_model_py + numTeams_ * department_index,
-             pTransition_model_py + numTeams_ * (department_index + 1), Team2KnapsackM[department_index].begin());
-        copy(pTEAMS_WEIGHTS_PER_DEPARTMENT_PY + numTeams_ * department_index,
-             pTEAMS_WEIGHTS_PER_DEPARTMENT_PY + numTeams_ * (department_index + 1),
-             TeamsWeightsPerDepartment[department_index].begin());
-        copy(p_NON_ZERO_WEIGHT_INDICES_PY + maxSizeNonzeroWeights_ * department_index,
-             p_NON_ZERO_WEIGHT_INDICES_PY + pNON_ZERO_WEIGHT_INDICES_SIZES_PY[department_index]
-                 + maxSizeNonzeroWeights_ * department_index,
-             NonZeroWeightIndices[department_index].begin());
+        NonZeroWeightIndices.push_back(vector<int>(pNON_ZERO_WEIGHT_INDICES_SIZES_PY[i], 0));
+        copy(pTransition_model_py + numTeams_ * i,
+             pTransition_model_py + numTeams_ * (i + 1), Team2KnapsackM[i].begin());
+        copy(pTEAMS_WEIGHTS_PER_DEPARTMENT_PY + numTeams_ * i,
+             pTEAMS_WEIGHTS_PER_DEPARTMENT_PY + numTeams_ * (i + 1),
+             TeamsWeightsPerDepartment[i].begin());
+        copy(p_NON_ZERO_WEIGHT_INDICES_PY + maxSizeNonzeroWeights_ * i,
+             p_NON_ZERO_WEIGHT_INDICES_PY + pNON_ZERO_WEIGHT_INDICES_SIZES_PY[i]
+                 + maxSizeNonzeroWeights_ * i,
+             NonZeroWeightIndices[i].begin());
     }
-    for (int project_index = 0; project_index < numProjects_; project_index++)
+    for (int i = 0; i < numProjects_; i++)
     {
         // Copy reward values for each project-team combination
-        copy(pREWARD_PROJECT_PY + numTeams_ * project_index, pREWARD_PROJECT_PY + numTeams_ * (project_index + 1),
-             RewardProject[project_index].begin());
+        copy(pREWARD_PROJECT_PY + numTeams_ * i, pREWARD_PROJECT_PY + numTeams_ * (i + 1),
+             RewardProject[i].begin());
     }
 }
 
@@ -172,14 +172,14 @@ void OutputsKcMwm::intrinsic_out_mwm_update(vector<vector<impalib_type>> &rOric2
                                             vector<vector<impalib_type>> &rProject2EqConstraintM,
                                             vector<vector<impalib_type>> &rRewardProject)
 {
-    for (int project_index = 0; project_index < rRewardProject.size(); project_index++)
+    for (int i = 0; i < rRewardProject.size(); i++)  // over projects
     {
-        for (int team_index = 0; team_index < rRewardProject[project_index].size(); team_index++)
+        for (int j = 0; j < rRewardProject[i].size(); j++)  // over teams
         {
             // Calculate the intrinsic output for the project-team combination
-            IntrinsicOutMwm[project_index + team_index + project_index * (numTeams_ - 1)] =
-                rOric2EqConstraintM[project_index][team_index] + rProject2EqConstraintM[project_index][team_index]
-                + rRewardProject[project_index][team_index];
+            IntrinsicOutMwm[i + j + i * (numTeams_ - 1)] =
+                rOric2EqConstraintM[i][j] + rProject2EqConstraintM[i][j]
+                + rRewardProject[i][j];
         }
     }
 }
@@ -197,11 +197,11 @@ void OutputsKcMwm::extrinsic_output_team_update(vector<vector<impalib_type>> &rE
 {
     copy(rOric2TeamM.begin(), rOric2TeamM.end(), ExtrinsicOutputTeam.begin());
 
-    for (int department_index = 0; department_index < rExtrinsicOutputDepartment.size(); department_index++)
+    for (int i = 0; i < rExtrinsicOutputDepartment.size(); i++)
     {
         // Calculate rExtrinsicOutputDepartment by adding rOric2TeamM
-        transform(rExtrinsicOutputDepartment[department_index].begin(),
-                  rExtrinsicOutputDepartment[department_index].end(), ExtrinsicOutputTeam.begin(),
+        transform(rExtrinsicOutputDepartment[i].begin(),
+                  rExtrinsicOutputDepartment[i].end(), ExtrinsicOutputTeam.begin(),
                   ExtrinsicOutputTeam.begin(), std::plus<impalib_type>());
     }
 }
@@ -305,31 +305,31 @@ void InputsTsp::process_inputs(const int *pEDGE_CONNECTIONS_PY, const impalib_ty
     copy(pCOST_EDGE_VARIABLE_PY, pCOST_EDGE_VARIABLE_PY + numEdgeVariables_, back_inserter(CostEdgeVariable));
 
     // Process input variables
-    for (int edge_variable_index = 0; edge_variable_index < numEdgeVariables_; edge_variable_index++)
+    for (int i = 0; i < numEdgeVariables_; i++)
     {
         // Copy edge connections
         EdgeConnections.push_back(vector<int>(numNodesPerEdge_, 0));
-        copy(pEDGE_CONNECTIONS_PY + numNodesPerEdge_ * edge_variable_index,
-             pEDGE_CONNECTIONS_PY + numNodesPerEdge_ * (edge_variable_index + 1),
-             EdgeConnections[edge_variable_index].begin());
+        copy(pEDGE_CONNECTIONS_PY + numNodesPerEdge_ * i,
+             pEDGE_CONNECTIONS_PY + numNodesPerEdge_ * (i + 1),
+             EdgeConnections[i].begin());
         // Copy edge ec to degree constraint messages
         EdgeEc2DegreeConstraintM.push_back(vector<impalib_type>(numNodes_, zero_value));
-        copy(pEdge_ec_to_degree_constraint_m_py + numNodes_ * edge_variable_index,
-             pEdge_ec_to_degree_constraint_m_py + numNodes_ * (edge_variable_index + 1),
-             EdgeEc2DegreeConstraintM[edge_variable_index].begin());
+        copy(pEdge_ec_to_degree_constraint_m_py + numNodes_ * i,
+             pEdge_ec_to_degree_constraint_m_py + numNodes_ * (i + 1),
+             EdgeEc2DegreeConstraintM[i].begin());
         // Copy edge degree constraint cost
         EdgeDegreeConstraintCost.push_back(vector<impalib_type>(numNodes_, zero_value));
-        copy(pEDGE_DEGREE_CONSTRAINT_COST_PY + numNodes_ * edge_variable_index,
-             pEDGE_DEGREE_CONSTRAINT_COST_PY + numNodes_ * (edge_variable_index + 1),
-             EdgeDegreeConstraintCost[edge_variable_index].begin());
+        copy(pEDGE_DEGREE_CONSTRAINT_COST_PY + numNodes_ * i,
+             pEDGE_DEGREE_CONSTRAINT_COST_PY + numNodes_ * (i + 1),
+             EdgeDegreeConstraintCost[i].begin());
     }
 
     // Process cost matrix
-    for (int node_index = 0; node_index < numNodes_; node_index++)
+    for (int i = 0; i < numNodes_; i++)
     {
         CostMatrix.push_back(vector<impalib_type>(numNodes_, zero_value));
-        copy(pCOST_MATRIX_PY + numNodes_ * node_index, pCOST_MATRIX_PY + numNodes_ * (node_index + 1),
-             CostMatrix[node_index].begin());
+        copy(pCOST_MATRIX_PY + numNodes_ * i, pCOST_MATRIX_PY + numNodes_ * (i + 1),
+             CostMatrix[i].begin());
     }
 }
 
@@ -344,12 +344,11 @@ void OutputsTsp::extrinsic_output_edge_ec_relaxed_graph_update(
     vector<vector<impalib_type>> &rDegreeConstraint2EqConstraintM)
 {
 
-    for (int edge_variable_index = 0; edge_variable_index < rDegreeConstraint2EqConstraintM.size();
-         edge_variable_index++)
+    for (int i = 0; i < rDegreeConstraint2EqConstraintM.size(); i++)
     {
-        ExtrinsicOutputEdgeEc[edge_variable_index] =
-            accumulate(rDegreeConstraint2EqConstraintM[edge_variable_index].begin(),
-                       rDegreeConstraint2EqConstraintM[edge_variable_index].end(), zero_value);
+        ExtrinsicOutputEdgeEc[i] =
+            accumulate(rDegreeConstraint2EqConstraintM[i].begin(),
+                       rDegreeConstraint2EqConstraintM[i].end(), zero_value);
     }
 }
 
@@ -367,20 +366,18 @@ void OutputsTsp::extrinsic_output_edge_ec_augmented_graph_update(
 {
 
     // Update extrinsic output for edge equality constraints based on messages from degree constraints to equality constraints
-    for (int edge_variable_index = 0; edge_variable_index < rDegreeConstraint2EqConstraintM.size();
-         edge_variable_index++)
+    for (int i = 0; i < rDegreeConstraint2EqConstraintM.size(); i++)
     {
-        ExtrinsicOutputEdgeEc[edge_variable_index] =
-            accumulate(rDegreeConstraint2EqConstraintM[edge_variable_index].begin(),
-                       rDegreeConstraint2EqConstraintM[edge_variable_index].end(), zero_value);
+        ExtrinsicOutputEdgeEc[i] =
+            accumulate(rDegreeConstraint2EqConstraintM[i].begin(),
+                       rDegreeConstraint2EqConstraintM[i].end(), zero_value);
     }
 
     // Update extrinsic output for edge equality constraints based on messages from subtour elimination constraints
-    for (int subtour_constraint_index = 0; subtour_constraint_index < rSubtourConstraints2EdgeEcM.size();
-         subtour_constraint_index++)
+    for (int i = 0; i < rSubtourConstraints2EdgeEcM.size(); i++)
     {
-        transform(rSubtourConstraints2EdgeEcM[subtour_constraint_index].begin(),
-                  rSubtourConstraints2EdgeEcM[subtour_constraint_index].end(), ExtrinsicOutputEdgeEc.begin(),
+        transform(rSubtourConstraints2EdgeEcM[i].begin(),
+                  rSubtourConstraints2EdgeEcM[i].end(), ExtrinsicOutputEdgeEc.begin(),
                   ExtrinsicOutputEdgeEc.begin(), plus<impalib_type>());
     }
 }

--- a/include/impalib/input_output.hpp
+++ b/include/impalib/input_output.hpp
@@ -56,14 +56,9 @@ class OutputsKcMwm {
  * @param[in] N_TEAMS: number of teams
  * @param[in] N_PROJECTS: number of projects
  * @param[in] MAX_SIZE_NON_ZERO_WEIGHTS: maximum number of connections between teams and departments
- * @param[out] numDepartments_: N_DEPARTMENTS
- * @param[out] numTeams_: N_TEAMS
- * @param[out] numProjects_: N_PROJECTS
- * @param[out] maxSizeNonzeroWeights_: MAX_SIZE_NON_ZERO_WEIGHTS
  *
  */
-
-InputsKcMwm::InputsKcMwm(const int N_DEPARTMENTS, const int N_TEAMS, const int N_PROJECTS, const int MAX_SIZE_NON_ZERO_WEIGHTS)
+inline InputsKcMwm::InputsKcMwm(const int N_DEPARTMENTS, const int N_TEAMS, const int N_PROJECTS, const int MAX_SIZE_NON_ZERO_WEIGHTS)
     : numDepartments_(N_DEPARTMENTS), numTeams_(N_TEAMS), numProjects_(N_PROJECTS), maxSizeNonzeroWeights_(MAX_SIZE_NON_ZERO_WEIGHTS) {
     weights.reserve(numDepartments_);
     NonZeroWeightIndices.reserve(numDepartments_);
@@ -94,8 +89,7 @@ InputsKcMwm::InputsKcMwm(const int N_DEPARTMENTS, const int N_TEAMS, const int N
  * @param[in] pMAX_STATE_PY: contains maximum capacity of departments
  *
  */
-
-void InputsKcMwm::process_inputs(const impalib_type *pREWARD_TEAM_PY, const impalib_type *pTransition_model_py, const int *pTEAMS_WEIGHTS_PER_DEPARTMENT_PY,
+inline void InputsKcMwm::process_inputs(const impalib_type *pREWARD_TEAM_PY, const impalib_type *pTransition_model_py, const int *pTEAMS_WEIGHTS_PER_DEPARTMENT_PY,
                                  const int *pNON_ZERO_WEIGHT_INDICES_SIZES_PY, const int *p_NON_ZERO_WEIGHT_INDICES_PY, const impalib_type *pREWARD_PROJECT_PY, const int *pMAX_STATE_PY) {
     // Copy reward values for each team and maximum states per department
     copy(pREWARD_TEAM_PY, pREWARD_TEAM_PY + numTeams_, back_inserter(RewardTeam));
@@ -121,13 +115,9 @@ void InputsKcMwm::process_inputs(const impalib_type *pREWARD_TEAM_PY, const impa
  * @param[in] N_DEPARTMENTS: number of departments
  * @param[in] N_TEAMS: number of teams
  * @param[in] N_PROJECTS: number of projects
- * @param[out] numDepartments_: N_DEPARTMENTS
- * @param[out] numTeams_: N_TEAMS
- * @param[out] numProjects_: N_PROJECTS
  *
  */
-
-OutputsKcMwm::OutputsKcMwm(const int N_DEPARTMENTS, const int N_TEAMS, const int N_PROJECTS)
+inline OutputsKcMwm::OutputsKcMwm(const int N_DEPARTMENTS, const int N_TEAMS, const int N_PROJECTS)
     : numDepartments_(N_DEPARTMENTS), numTeams_(N_TEAMS), numProjects_(N_PROJECTS), extrinsic(numTeams_, 0), intrinsic(numProjects_ * numTeams_, 0){};
 
 /**
@@ -138,8 +128,7 @@ OutputsKcMwm::OutputsKcMwm(const int N_DEPARTMENTS, const int N_TEAMS, const int
  * @param[in] reward: rewards of project-team combinations
  *
  */
-
-void OutputsKcMwm::update_intrinsic(const vector<vector<impalib_type>> &oric2eq, const vector<vector<impalib_type>> &project2eq, const vector<vector<impalib_type>> &reward) {
+inline void OutputsKcMwm::update_intrinsic(const vector<vector<impalib_type>> &oric2eq, const vector<vector<impalib_type>> &project2eq, const vector<vector<impalib_type>> &reward) {
     for (int i = 0; i < reward.size(); i++)  // over projects
     {
         for (int j = 0; j < reward[i].size(); j++)  // over teams
@@ -157,8 +146,7 @@ void OutputsKcMwm::update_intrinsic(const vector<vector<impalib_type>> &oric2eq,
  * @param[in] oric2team: messages from ORIC to team equality constraints
  *
  */
-
-void OutputsKcMwm::update_extrinsic(const vector<vector<impalib_type>> &extrinsic_out, const vector<impalib_type> &oric2team) {
+inline void OutputsKcMwm::update_extrinsic(const vector<vector<impalib_type>> &extrinsic_out, const vector<impalib_type> &oric2team) {
     extrinsic = oric2team;
 
     for (int i = 0; i < extrinsic_out.size(); i++) {
@@ -192,12 +180,9 @@ class InputsTsp {
  *
  * @param[in] NUM_NODES: number of nodes
  * @param[in] NUM_EDGE_VARIABLES: number of edge variables (edge connections)
- * @param[out] numNodes_: NUM_NODES
- * @param[out] numEdgeVariables_: NUM_EDGE_VARIABLES
  *
  */
-
-InputsTsp::InputsTsp(const int NUM_NODES, const int NUM_EDGE_VARIABLES) : n_Nodes(NUM_NODES), n_Edges(NUM_EDGE_VARIABLES){};
+inline InputsTsp::InputsTsp(const int NUM_NODES, const int NUM_EDGE_VARIABLES) : n_Nodes(NUM_NODES), n_Edges(NUM_EDGE_VARIABLES){};
 
 /**
  * Represents a class for outputs of TSP
@@ -222,12 +207,9 @@ class OutputsTsp {
  *
  * @param[in] NUM_NODES: number of nodes
  * @param[in] NUM_EDGE_VARIABLES: number of edge variables (edge connections)
- * @param[out] numNodes_: NUM_NODES
- * @param[out] numEdgeVariables_: NUM_EDGE_VARIABLES
  *
  */
-
-OutputsTsp::OutputsTsp(const int NUM_NODES, const int NUM_EDGE_VARIABLES) : numNodes_(NUM_NODES), numEdgeVariables_(NUM_EDGE_VARIABLES) {
+inline OutputsTsp::OutputsTsp(const int NUM_NODES, const int NUM_EDGE_VARIABLES) : numNodes_(NUM_NODES), numEdgeVariables_(NUM_EDGE_VARIABLES) {
     // Reserve and initialize memory for extrinsic_ and intrinsic edge equality constraints outputs
     extrinsic.reserve(numEdgeVariables_);
     extrinsic.resize(numEdgeVariables_);
@@ -248,8 +230,7 @@ OutputsTsp::OutputsTsp(const int NUM_NODES, const int NUM_EDGE_VARIABLES) : numN
  * Refer to example of TSP to understand how the various costs differ. The various various will facilitate computations in the IMPA
  *
  */
-
-void InputsTsp::process_inputs(const int *pEDGE_CONNECTIONS_PY, const impalib_type *pCOST_EDGE_VARIABLE_PY, const impalib_type *pCOST_MATRIX_PY, const impalib_type *pEdge_ec_to_degree_constraint_m_py,
+inline void InputsTsp::process_inputs(const int *pEDGE_CONNECTIONS_PY, const impalib_type *pCOST_EDGE_VARIABLE_PY, const impalib_type *pCOST_MATRIX_PY, const impalib_type *pEdge_ec_to_degree_constraint_m_py,
                                const impalib_type *pEDGE_DEGREE_CONSTRAINT_COST_PY) {
     // Copy cost edge variable data
     copy(pCOST_EDGE_VARIABLE_PY, pCOST_EDGE_VARIABLE_PY + n_Edges, back_inserter(cost_edge));
@@ -280,8 +261,7 @@ void InputsTsp::process_inputs(const int *pEDGE_CONNECTIONS_PY, const impalib_ty
  * @param[in] deg2eq: messages from degree constraints to edge equality constraints
  *
  */
-
-void OutputsTsp::update_extrinsic_relaxed(vector<vector<impalib_type>> &deg2eq) {
+inline void OutputsTsp::update_extrinsic_relaxed(vector<vector<impalib_type>> &deg2eq) {
     for (int i = 0; i < deg2eq.size(); i++) {
         extrinsic[i] = accumulate(deg2eq[i].begin(), deg2eq[i].end(), zero_value);
     }
@@ -294,8 +274,7 @@ void OutputsTsp::update_extrinsic_relaxed(vector<vector<impalib_type>> &deg2eq) 
  * @param[in] subtour2edge: messages from subtour elimination constraints to edge equality constraints
  *
  */
-
-void OutputsTsp::update_extrinsic_augmented(vector<vector<impalib_type>> &deg2eq, vector<vector<impalib_type>> &subtour2edge) {
+inline void OutputsTsp::update_extrinsic_augmented(vector<vector<impalib_type>> &deg2eq, vector<vector<impalib_type>> &subtour2edge) {
     // Update extrinsic_ output for edge equality constraints based on messages from degree constraints to equality constraints
     for (int i = 0; i < deg2eq.size(); i++) {
         extrinsic[i] = accumulate(deg2eq[i].begin(), deg2eq[i].end(), zero_value);
@@ -313,8 +292,7 @@ void OutputsTsp::update_extrinsic_augmented(vector<vector<impalib_type>> &deg2eq
  * @param[in] costs: cost of each edge equality constraint
  *
  */
-
-void OutputsTsp::update_intrinsic(vector<impalib_type> &costs) {
+inline void OutputsTsp::update_intrinsic(vector<impalib_type> &costs) {
     // Calculate intrinsic output for edge equality constraints by adding extrinsic_ output for edge equality constraints to cost edge variable
     transform(extrinsic.begin(), extrinsic.end(), costs.begin(), intrinsic.begin(), plus<impalib_type>());
 }

--- a/include/impalib/input_output.hpp
+++ b/include/impalib/input_output.hpp
@@ -11,45 +11,42 @@
 /**
  * Represents a class for inputs of Knapsack-MWMW problem
  */
-class InputsKcMwm
-{
-private:
-    int numTeams_; ///< number of teams
-    int numDepartments_; ///< number of departments
-    int numProjects_; ///< number of projects
-    int maxSizeNonzeroWeights_; ///< maximum # of non-zero weights over all departments
+class InputsKcMwm {
+   private:
+    int numTeams_;               ///< number of teams
+    int numDepartments_;         ///< number of departments
+    int numProjects_;            ///< number of projects
+    int maxSizeNonzeroWeights_;  ///< maximum # of non-zero weights over all departments
 
-public:
-    vector<impalib_type>         RewardTeam; ///< rewards of team equality constraints
-    vector<vector<impalib_type>> Team2KnapsackM; ///< messages from teams to knapsack constraints
-    vector<vector<int>>          TeamsWeightsPerDepartment; ///< weights of teams per each department
-    vector<vector<impalib_type>> RewardProject; ///< reward of project equality constraint
-    vector<int>                  MaxState; ///< vector of capacities of departments
-    vector<vector<int>>          NonZeroWeightIndices; ///< indices of non-zero weights per each department
+   public:
+    vector<impalib_type> RewardTeam;               ///< rewards of team equality constraints
+    vector<vector<impalib_type>> M_team2knapsack;  ///< messages from teams to knapsack constraints
+    vector<vector<int>> weights;                   ///< weights of teams per each department
+    vector<vector<impalib_type>> RewardProject;    ///< reward of project equality constraint
+    vector<int> capacity;                          ///< vector of capacities of departments
+    vector<vector<int>> NonZeroWeightIndices;      ///< indices of non-zero weights per each department
 
-    void process_inputs(const impalib_type *, const impalib_type *, const int *, const int *, const int *,
-                        const impalib_type *, const int *); ///< process input of graphical model
+    void process_inputs(const impalib_type *, const impalib_type *, const int *, const int *, const int *, const impalib_type *, const int *);  ///< process input of graphical model
 
-    InputsKcMwm(int N_DEPARTMENTS, int N_TEAMS, int N_PROJECTS, int MAX_SIZE_NON_ZERO_WEIGHTS); ///< constructor
+    InputsKcMwm(int N_DEPARTMENTS, int N_TEAMS, int N_PROJECTS, int MAX_SIZE_NON_ZERO_WEIGHTS);  ///< constructor
 };
 
 /**
  * Represents a class for outputs of Knapsack-MWMW problem
  */
-class OutputsKcMwm
-{
-private:
-    int numTeams_; ///< number of teams
-    int numDepartments_; ///< number of departments
-    int numProjects_; ///< number of projects
+class OutputsKcMwm {
+   private:
+    int numTeams_;        ///< number of teams
+    int numDepartments_;  ///< number of departments
+    int numProjects_;     ///< number of projects
 
-public:
-    vector<impalib_type> ExtrinsicOutputTeam; ///< extrinsic output of team equality constraints
-    vector<impalib_type> IntrinsicOutMwm; ///< intrinsic outputs of project equality constraint 
-    void update_intrinsic(const vector<vector<impalib_type>> &rOric2EqConstraintM, const vector<vector<impalib_type>> &rProject2EqConstraintM,
-                                                  const vector<vector<impalib_type>> &rRewardProject); ///< calculate intrinsic outputs of project equality constraints
-    void update_extrinsic(const vector<vector<impalib_type>> &rExtrinsicOutputDepartment, const vector<impalib_type> &rOric2TeamM); ///< calculate extrinsic output of team equality constraints
-    OutputsKcMwm(int N_DEPARTMENTS, int N_TEAMS, int N_PROJECTS); ///< constructor
+   public:
+    vector<impalib_type> extrinsic;  ///< extrinsic_ output of team equality constraints
+    vector<impalib_type> intrinsic;  ///< intrinsic outputs of project equality constraint
+    void update_intrinsic(const vector<vector<impalib_type>> &oric2eq, const vector<vector<impalib_type>> &project2eq,
+                          const vector<vector<impalib_type>> &reward);                                                ///< calculate intrinsic outputs of project equality constraints
+    void update_extrinsic(const vector<vector<impalib_type>> &extrinsic_out, const vector<impalib_type> &oric2team);  ///< calculate extrinsic_ output of team equality constraints
+    OutputsKcMwm(int N_DEPARTMENTS, int N_TEAMS, int N_PROJECTS);                                                     ///< constructor
 };
 
 /**
@@ -63,29 +60,24 @@ public:
  * @param[out] numTeams_: N_TEAMS
  * @param[out] numProjects_: N_PROJECTS
  * @param[out] maxSizeNonzeroWeights_: MAX_SIZE_NON_ZERO_WEIGHTS
- * 
+ *
  */
 
-InputsKcMwm::InputsKcMwm(const int N_DEPARTMENTS, const int N_TEAMS, const int N_PROJECTS,
-                         const int MAX_SIZE_NON_ZERO_WEIGHTS)
-    : numDepartments_(N_DEPARTMENTS), numTeams_(N_TEAMS), numProjects_(N_PROJECTS),
-      maxSizeNonzeroWeights_(MAX_SIZE_NON_ZERO_WEIGHTS)
-{
-    TeamsWeightsPerDepartment.reserve(numDepartments_);
+InputsKcMwm::InputsKcMwm(const int N_DEPARTMENTS, const int N_TEAMS, const int N_PROJECTS, const int MAX_SIZE_NON_ZERO_WEIGHTS)
+    : numDepartments_(N_DEPARTMENTS), numTeams_(N_TEAMS), numProjects_(N_PROJECTS), maxSizeNonzeroWeights_(MAX_SIZE_NON_ZERO_WEIGHTS) {
+    weights.reserve(numDepartments_);
     NonZeroWeightIndices.reserve(numDepartments_);
     RewardProject.reserve(numProjects_);
-    Team2KnapsackM.reserve(numDepartments_);
+    M_team2knapsack.reserve(numDepartments_);
 
-    // Initialize Team2KnapsackM and TeamsWeightsPerDepartment vectors
-    for (int i = 0; i < numDepartments_; i++)
-    {
-        Team2KnapsackM.push_back(vector<impalib_type>(numTeams_, zero_value));
-        TeamsWeightsPerDepartment.push_back(vector<int>(numTeams_, 0));
+    // Initialize M_team2knapsack and weights vectors
+    for (int i = 0; i < numDepartments_; i++) {
+        M_team2knapsack.push_back(vector<impalib_type>(numTeams_, zero_value));
+        weights.push_back(vector<int>(numTeams_, 0));
     }
 
     // Initialize RewardProject vector
-    for (int i = 0; i < numProjects_; i++)
-    {
+    for (int i = 0; i < numProjects_; i++) {
         RewardProject.push_back(vector<impalib_type>(numTeams_, zero_value));
     }
 };
@@ -100,38 +92,26 @@ InputsKcMwm::InputsKcMwm(const int N_DEPARTMENTS, const int N_TEAMS, const int N
  * @param[in] p_NON_ZERO_WEIGHT_INDICES_PY: non-zero connections between teams and departments
  * @param[in] pREWARD_PROJECT_PY: rewards for project-team combination
  * @param[in] pMAX_STATE_PY: contains maximum capacity of departments
- * 
+ *
  */
 
-void InputsKcMwm::process_inputs(const impalib_type *pREWARD_TEAM_PY, const impalib_type *pTransition_model_py,
-                                 const int *pTEAMS_WEIGHTS_PER_DEPARTMENT_PY,
-                                 const int *pNON_ZERO_WEIGHT_INDICES_SIZES_PY, const int *p_NON_ZERO_WEIGHT_INDICES_PY,
-                                 const impalib_type *pREWARD_PROJECT_PY, const int *pMAX_STATE_PY)
-{
-
+void InputsKcMwm::process_inputs(const impalib_type *pREWARD_TEAM_PY, const impalib_type *pTransition_model_py, const int *pTEAMS_WEIGHTS_PER_DEPARTMENT_PY,
+                                 const int *pNON_ZERO_WEIGHT_INDICES_SIZES_PY, const int *p_NON_ZERO_WEIGHT_INDICES_PY, const impalib_type *pREWARD_PROJECT_PY, const int *pMAX_STATE_PY) {
     // Copy reward values for each team and maximum states per department
     copy(pREWARD_TEAM_PY, pREWARD_TEAM_PY + numTeams_, back_inserter(RewardTeam));
-    copy(pMAX_STATE_PY, pMAX_STATE_PY + numDepartments_, back_inserter(MaxState));
+    copy(pMAX_STATE_PY, pMAX_STATE_PY + numDepartments_, back_inserter(capacity));
 
-    for (int i = 0; i < numDepartments_; i++)
-    {   
+    for (int i = 0; i < numDepartments_; i++) {
         // Populate NonZeroWeightIndices for the department
         NonZeroWeightIndices.push_back(vector<int>(pNON_ZERO_WEIGHT_INDICES_SIZES_PY[i], 0));
-        copy(pTransition_model_py + numTeams_ * i,
-             pTransition_model_py + numTeams_ * (i + 1), Team2KnapsackM[i].begin());
-        copy(pTEAMS_WEIGHTS_PER_DEPARTMENT_PY + numTeams_ * i,
-             pTEAMS_WEIGHTS_PER_DEPARTMENT_PY + numTeams_ * (i + 1),
-             TeamsWeightsPerDepartment[i].begin());
-        copy(p_NON_ZERO_WEIGHT_INDICES_PY + maxSizeNonzeroWeights_ * i,
-             p_NON_ZERO_WEIGHT_INDICES_PY + pNON_ZERO_WEIGHT_INDICES_SIZES_PY[i]
-                 + maxSizeNonzeroWeights_ * i,
+        copy(pTransition_model_py + numTeams_ * i, pTransition_model_py + numTeams_ * (i + 1), M_team2knapsack[i].begin());
+        copy(pTEAMS_WEIGHTS_PER_DEPARTMENT_PY + numTeams_ * i, pTEAMS_WEIGHTS_PER_DEPARTMENT_PY + numTeams_ * (i + 1), weights[i].begin());
+        copy(p_NON_ZERO_WEIGHT_INDICES_PY + maxSizeNonzeroWeights_ * i, p_NON_ZERO_WEIGHT_INDICES_PY + pNON_ZERO_WEIGHT_INDICES_SIZES_PY[i] + maxSizeNonzeroWeights_ * i,
              NonZeroWeightIndices[i].begin());
     }
-    for (int i = 0; i < numProjects_; i++)
-    {
+    for (int i = 0; i < numProjects_; i++) {
         // Copy reward values for each project-team combination
-        copy(pREWARD_PROJECT_PY + numTeams_ * i, pREWARD_PROJECT_PY + numTeams_ * (i + 1),
-             RewardProject[i].begin());
+        copy(pREWARD_PROJECT_PY + numTeams_ * i, pREWARD_PROJECT_PY + numTeams_ * (i + 1), RewardProject[i].begin());
     }
 }
 
@@ -144,81 +124,67 @@ void InputsKcMwm::process_inputs(const impalib_type *pREWARD_TEAM_PY, const impa
  * @param[out] numDepartments_: N_DEPARTMENTS
  * @param[out] numTeams_: N_TEAMS
  * @param[out] numProjects_: N_PROJECTS
- * 
+ *
  */
 
 OutputsKcMwm::OutputsKcMwm(const int N_DEPARTMENTS, const int N_TEAMS, const int N_PROJECTS)
-    : numDepartments_(N_DEPARTMENTS), numTeams_(N_TEAMS), numProjects_(N_PROJECTS),
-      ExtrinsicOutputTeam(numTeams_, 0), IntrinsicOutMwm(numProjects_ * numTeams_, 0)
-{
-};
+    : numDepartments_(N_DEPARTMENTS), numTeams_(N_TEAMS), numProjects_(N_PROJECTS), extrinsic(numTeams_, 0), intrinsic(numProjects_ * numTeams_, 0){};
 
 /**
  * Calculate instrinsic messages of project equality constraint for Knapsack-MWM problem
  *
- * @param[in] rOric2EqConstraintM: messages for ORIC to equality constraint of the projects
- * @param[in] rProject2EqConstraintM: messages from projects to equality constraints of the projects
- * @param[in] rRewardProject: rewards of project-team combinations
- * 
+ * @param[in] oric2eq: messages for ORIC to equality constraint of the projects
+ * @param[in] project2eq: messages from projects to equality constraints of the projects
+ * @param[in] reward: rewards of project-team combinations
+ *
  */
 
-void OutputsKcMwm::update_intrinsic(const vector<vector<impalib_type>> &rOric2EqConstraintM,
-                                    const vector<vector<impalib_type>> &rProject2EqConstraintM,
-                                    const vector<vector<impalib_type>> &rRewardProject)
-{
-    for (int i = 0; i < rRewardProject.size(); i++)  // over projects
+void OutputsKcMwm::update_intrinsic(const vector<vector<impalib_type>> &oric2eq, const vector<vector<impalib_type>> &project2eq, const vector<vector<impalib_type>> &reward) {
+    for (int i = 0; i < reward.size(); i++)  // over projects
     {
-        for (int j = 0; j < rRewardProject[i].size(); j++)  // over teams
+        for (int j = 0; j < reward[i].size(); j++)  // over teams
         {
             // Calculate the intrinsic output for the project-team combination
-            IntrinsicOutMwm[i + j + i * (numTeams_ - 1)] =
-                rOric2EqConstraintM[i][j] + rProject2EqConstraintM[i][j]
-                + rRewardProject[i][j];
+            intrinsic[i + j + i * (numTeams_ - 1)] = oric2eq[i][j] + project2eq[i][j] + reward[i][j];
         }
     }
 }
 
 /**
- * Calculate extrinsic messages of team equality constraint for Knapsack-MWM problem
+ * Calculate extrinsic_ messages of team equality constraint for Knapsack-MWM problem
  *
- * @param[in] rExtrinsicOutputDepartment: messages from knapsack constraints to team equality constraints
- * @param[in] rOric2TeamM: messages from ORIC to team equality constraints
- * 
+ * @param[in] extrinsic_out: messages from knapsack constraints to team equality constraints
+ * @param[in] oric2team: messages from ORIC to team equality constraints
+ *
  */
 
-void OutputsKcMwm::update_extrinsic(const vector<vector<impalib_type>> &rExtrinsicOutputDepartment,
-                                                const vector<impalib_type>         &rOric2TeamM)
-{
-    ExtrinsicOutputTeam = rOric2TeamM;
+void OutputsKcMwm::update_extrinsic(const vector<vector<impalib_type>> &extrinsic_out, const vector<impalib_type> &oric2team) {
+    extrinsic = oric2team;
 
-    for (int i = 0; i < rExtrinsicOutputDepartment.size(); i++)
-    {
-        transform(rExtrinsicOutputDepartment[i].begin(),
-                  rExtrinsicOutputDepartment[i].end(), ExtrinsicOutputTeam.begin(),
-                  ExtrinsicOutputTeam.begin(), std::plus<impalib_type>());
+    for (int i = 0; i < extrinsic_out.size(); i++) {
+        transform(extrinsic_out[i].begin(), extrinsic_out[i].end(), extrinsic.begin(), extrinsic.begin(), std::plus<impalib_type>());
     }
 }
 
 /**
  * Represents a class for inputs of TSP
  */
-class InputsTsp
-{
-private:
-    int numNodes_; ///< number of nodes of TSP
-    int numEdgeVariables_; ///< number of edges of TSP
-    int numNodesPerEdge_ = 2; ///< number of nodes per edge
+class InputsTsp {
+   private:
+    int n_Nodes;             ///< number of nodes of TSP
+    int n_Edges;             ///< number of edges of TSP
+    int n_NodesPerEdge = 2;  ///< number of nodes per edge
 
-public:
-    vector<vector<int>>          EdgeConnections; ///< constituent nodes per each edge
-    vector<impalib_type>         CostEdgeVariable; ///< cost for each edge equality constraint
-    vector<vector<impalib_type>> CostMatrix; ///< cost matrix (n_nodesxn_nodes)
-    vector<vector<impalib_type>> EdgeDegreeConstraintCost; ///< cost matrix represented as num_edges x num_nodes to facilitate message updates
-    vector<vector<impalib_type>> EdgeEc2DegreeConstraintM; ///< messages from edge equality constraint to degree constraint
+   public:
+    vector<vector<int>> edges;                   ///< constituent nodes per each edge
+    vector<impalib_type> cost_edge;              ///< cost for each edge equality constraint
+    vector<vector<impalib_type>> cost;           ///< cost matrix (n_nodesxn_nodes)
+    vector<vector<impalib_type>> cost_edge_mat;  ///< cost matrix represented as num_edges x num_nodes to facilitate message updates
+    vector<vector<impalib_type>> M_edge2degree;  ///< messages from edge equality constraint to degree constraint
 
-    void process_inputs(const int *, const impalib_type *, const impalib_type *, const impalib_type *, const impalib_type *); ///< process inputs of TSP graphical model
+    void process_inputs(const int *, const impalib_type *, const impalib_type *, const impalib_type *, const impalib_type *);  ///< process inputs of TSP graphical model
 
-    InputsTsp(const int NUM_NODES, const int NUM_EDGE_VARIABLES); ///< constructor
+    InputsTsp(const int NUM_NODES, const int NUM_EDGE_VARIABLES);  ///< constructor
 };
 
 /**
@@ -228,30 +194,27 @@ public:
  * @param[in] NUM_EDGE_VARIABLES: number of edge variables (edge connections)
  * @param[out] numNodes_: NUM_NODES
  * @param[out] numEdgeVariables_: NUM_EDGE_VARIABLES
- * 
+ *
  */
 
-InputsTsp::InputsTsp(const int NUM_NODES, const int NUM_EDGE_VARIABLES)
-    : numNodes_(NUM_NODES), numEdgeVariables_(NUM_EDGE_VARIABLES){
-                            };
+InputsTsp::InputsTsp(const int NUM_NODES, const int NUM_EDGE_VARIABLES) : n_Nodes(NUM_NODES), n_Edges(NUM_EDGE_VARIABLES){};
 
 /**
  * Represents a class for outputs of TSP
  */
-class OutputsTsp
-{
-private:
-    int numNodes_; ///< number of nodes
-    int numEdgeVariables_; ///< number of edges
+class OutputsTsp {
+   private:
+    int numNodes_;          ///< number of nodes
+    int numEdgeVariables_;  ///< number of edges
 
-public:
-    vector<impalib_type> ExtrinsicOutputEdgeEc; ///< extrinsic output of edge equality constraint
-    vector<impalib_type> IntrinsicOutputEdgeEc; ///< intrinsic output of edge equality constraint
-    void update_extrinsic_relaxed(vector<vector<impalib_type>> &rDegreeConstraint2EqConstraintM); ///< calculate extrinsic output of edge equality constraint for a relaxed TSP
-    void update_extrinsic_augmented(vector<vector<impalib_type>> &rDegreeConstraint2EqConstraintM,
-                                                                         vector<vector<impalib_type>> &rSubtourConstraints2EdgeEcM); ///< calculate extrinsic output of edge equality constraint for augmented TSP
-    void update_intrinsic(vector<impalib_type> &rCostEdgeVariable); ///< calculate intrinsic output of edge equality constraint for augmented TSP
-    OutputsTsp(const int NUM_NODES, const int NUM_EDGE_VARIABLES); ///< constructor
+   public:
+    vector<impalib_type> extrinsic;                                       ///< extrinsic_ output of edge equality constraint
+    vector<impalib_type> intrinsic;                                       ///< intrinsic output of edge equality constraint
+    void update_extrinsic_relaxed(vector<vector<impalib_type>> &deg2eq);  ///< calculate extrinsic_ output of edge equality constraint for a relaxed TSP
+    void update_extrinsic_augmented(vector<vector<impalib_type>> &deg2eq,
+                                    vector<vector<impalib_type>> &subtour2edge);  ///< calculate extrinsic_ output of edge equality constraint for augmented TSP
+    void update_intrinsic(vector<impalib_type> &costs);                           ///< calculate intrinsic output of edge equality constraint for augmented TSP
+    OutputsTsp(const int NUM_NODES, const int NUM_EDGE_VARIABLES);                ///< constructor
 };
 
 /**
@@ -261,20 +224,17 @@ public:
  * @param[in] NUM_EDGE_VARIABLES: number of edge variables (edge connections)
  * @param[out] numNodes_: NUM_NODES
  * @param[out] numEdgeVariables_: NUM_EDGE_VARIABLES
- * 
+ *
  */
 
-OutputsTsp::OutputsTsp(const int NUM_NODES, const int NUM_EDGE_VARIABLES)
-    : numNodes_(NUM_NODES), numEdgeVariables_(NUM_EDGE_VARIABLES)
-{
-
-    // Reserve and initialize memory for extrinsic and intrinsic edge equality constraints outputs
-    ExtrinsicOutputEdgeEc.reserve(numEdgeVariables_);
-    ExtrinsicOutputEdgeEc.resize(numEdgeVariables_);
-    IntrinsicOutputEdgeEc.reserve(numEdgeVariables_);
-    IntrinsicOutputEdgeEc.resize(numEdgeVariables_);
-    fill(ExtrinsicOutputEdgeEc.begin(), ExtrinsicOutputEdgeEc.begin() + numEdgeVariables_, zero_value);
-    fill(IntrinsicOutputEdgeEc.begin(), IntrinsicOutputEdgeEc.begin() + numEdgeVariables_, zero_value);
+OutputsTsp::OutputsTsp(const int NUM_NODES, const int NUM_EDGE_VARIABLES) : numNodes_(NUM_NODES), numEdgeVariables_(NUM_EDGE_VARIABLES) {
+    // Reserve and initialize memory for extrinsic_ and intrinsic edge equality constraints outputs
+    extrinsic.reserve(numEdgeVariables_);
+    extrinsic.resize(numEdgeVariables_);
+    intrinsic.reserve(numEdgeVariables_);
+    intrinsic.resize(numEdgeVariables_);
+    fill(extrinsic.begin(), extrinsic.begin() + numEdgeVariables_, zero_value);
+    fill(intrinsic.begin(), intrinsic.begin() + numEdgeVariables_, zero_value);
 };
 
 /**
@@ -284,108 +244,77 @@ OutputsTsp::OutputsTsp(const int NUM_NODES, const int NUM_EDGE_VARIABLES)
  * @param[in] pCOST_EDGE_VARIABLE_PY: cost for each possible connection between nodes. This has size of number of edges
  * @param[in] pCOST_MATRIX_PY: cost matrix of size number of nodes x number of nodes
  * @param[in] pEdge_ec_to_degree_constraint_m_py: messages from edges equality constraints to degree constraints
- * @param[in] pEDGE_DEGREE_CONSTRAINT_COST_PY: another matrix of costs that has size number of edges x number of nodes. 
+ * @param[in] pEDGE_DEGREE_CONSTRAINT_COST_PY: another matrix of costs that has size number of edges x number of nodes.
  * Refer to example of TSP to understand how the various costs differ. The various various will facilitate computations in the IMPA
- * 
+ *
  */
 
-void InputsTsp::process_inputs(const int *pEDGE_CONNECTIONS_PY, const impalib_type *pCOST_EDGE_VARIABLE_PY,
-                               const impalib_type *pCOST_MATRIX_PY, const impalib_type *pEdge_ec_to_degree_constraint_m_py,
-                               const impalib_type *pEDGE_DEGREE_CONSTRAINT_COST_PY)
-{
-
+void InputsTsp::process_inputs(const int *pEDGE_CONNECTIONS_PY, const impalib_type *pCOST_EDGE_VARIABLE_PY, const impalib_type *pCOST_MATRIX_PY, const impalib_type *pEdge_ec_to_degree_constraint_m_py,
+                               const impalib_type *pEDGE_DEGREE_CONSTRAINT_COST_PY) {
     // Copy cost edge variable data
-    copy(pCOST_EDGE_VARIABLE_PY, pCOST_EDGE_VARIABLE_PY + numEdgeVariables_, back_inserter(CostEdgeVariable));
+    copy(pCOST_EDGE_VARIABLE_PY, pCOST_EDGE_VARIABLE_PY + n_Edges, back_inserter(cost_edge));
 
     // Process input variables
-    for (int i = 0; i < numEdgeVariables_; i++)
-    {
+    for (int i = 0; i < n_Edges; i++) {
         // Copy edge connections
-        EdgeConnections.push_back(vector<int>(numNodesPerEdge_, 0));
-        copy(pEDGE_CONNECTIONS_PY + numNodesPerEdge_ * i,
-             pEDGE_CONNECTIONS_PY + numNodesPerEdge_ * (i + 1),
-             EdgeConnections[i].begin());
+        edges.push_back(vector<int>(n_NodesPerEdge, 0));
+        copy(pEDGE_CONNECTIONS_PY + n_NodesPerEdge * i, pEDGE_CONNECTIONS_PY + n_NodesPerEdge * (i + 1), edges[i].begin());
         // Copy edge ec to degree constraint messages
-        EdgeEc2DegreeConstraintM.push_back(vector<impalib_type>(numNodes_, zero_value));
-        copy(pEdge_ec_to_degree_constraint_m_py + numNodes_ * i,
-             pEdge_ec_to_degree_constraint_m_py + numNodes_ * (i + 1),
-             EdgeEc2DegreeConstraintM[i].begin());
+        M_edge2degree.push_back(vector<impalib_type>(n_Nodes, zero_value));
+        copy(pEdge_ec_to_degree_constraint_m_py + n_Nodes * i, pEdge_ec_to_degree_constraint_m_py + n_Nodes * (i + 1), M_edge2degree[i].begin());
         // Copy edge degree constraint cost
-        EdgeDegreeConstraintCost.push_back(vector<impalib_type>(numNodes_, zero_value));
-        copy(pEDGE_DEGREE_CONSTRAINT_COST_PY + numNodes_ * i,
-             pEDGE_DEGREE_CONSTRAINT_COST_PY + numNodes_ * (i + 1),
-             EdgeDegreeConstraintCost[i].begin());
+        cost_edge_mat.push_back(vector<impalib_type>(n_Nodes, zero_value));
+        copy(pEDGE_DEGREE_CONSTRAINT_COST_PY + n_Nodes * i, pEDGE_DEGREE_CONSTRAINT_COST_PY + n_Nodes * (i + 1), cost_edge_mat[i].begin());
     }
 
     // Process cost matrix
-    for (int i = 0; i < numNodes_; i++)
-    {
-        CostMatrix.push_back(vector<impalib_type>(numNodes_, zero_value));
-        copy(pCOST_MATRIX_PY + numNodes_ * i, pCOST_MATRIX_PY + numNodes_ * (i + 1),
-             CostMatrix[i].begin());
+    for (int i = 0; i < n_Nodes; i++) {
+        cost.push_back(vector<impalib_type>(n_Nodes, zero_value));
+        copy(pCOST_MATRIX_PY + n_Nodes * i, pCOST_MATRIX_PY + n_Nodes * (i + 1), cost[i].begin());
     }
 }
 
 /**
- * Calculate output extrinsic messages of edge equality constraint for relaxed TSP
+ * Calculate output extrinsic_ messages of edge equality constraint for relaxed TSP
  *
- * @param[in] rDegreeConstraint2EqConstraintM: messages from degree constraints to edge equality constraints
- * 
+ * @param[in] deg2eq: messages from degree constraints to edge equality constraints
+ *
  */
 
-void OutputsTsp::update_extrinsic_relaxed(
-    vector<vector<impalib_type>> &rDegreeConstraint2EqConstraintM)
-{
-
-    for (int i = 0; i < rDegreeConstraint2EqConstraintM.size(); i++)
-    {
-        ExtrinsicOutputEdgeEc[i] =
-            accumulate(rDegreeConstraint2EqConstraintM[i].begin(),
-                       rDegreeConstraint2EqConstraintM[i].end(), zero_value);
+void OutputsTsp::update_extrinsic_relaxed(vector<vector<impalib_type>> &deg2eq) {
+    for (int i = 0; i < deg2eq.size(); i++) {
+        extrinsic[i] = accumulate(deg2eq[i].begin(), deg2eq[i].end(), zero_value);
     }
 }
 
 /**
- * Calculate output extrinsic messages of edge equality constraint for augmented TSP
+ * Calculate output extrinsic_ messages of edge equality constraint for augmented TSP
  *
- * @param[in] rDegreeConstraint2EqConstraintM: messages from degree constraints to edge equality constraints
- * @param[in] rSubtourConstraints2EdgeEcM: messages from subtour elimination constraints to edge equality constraints
- * 
+ * @param[in] deg2eq: messages from degree constraints to edge equality constraints
+ * @param[in] subtour2edge: messages from subtour elimination constraints to edge equality constraints
+ *
  */
 
-void OutputsTsp::update_extrinsic_augmented(
-    vector<vector<impalib_type>> &rDegreeConstraint2EqConstraintM,
-    vector<vector<impalib_type>> &rSubtourConstraints2EdgeEcM)
-{
-
-    // Update extrinsic output for edge equality constraints based on messages from degree constraints to equality constraints
-    for (int i = 0; i < rDegreeConstraint2EqConstraintM.size(); i++)
-    {
-        ExtrinsicOutputEdgeEc[i] =
-            accumulate(rDegreeConstraint2EqConstraintM[i].begin(),
-                       rDegreeConstraint2EqConstraintM[i].end(), zero_value);
+void OutputsTsp::update_extrinsic_augmented(vector<vector<impalib_type>> &deg2eq, vector<vector<impalib_type>> &subtour2edge) {
+    // Update extrinsic_ output for edge equality constraints based on messages from degree constraints to equality constraints
+    for (int i = 0; i < deg2eq.size(); i++) {
+        extrinsic[i] = accumulate(deg2eq[i].begin(), deg2eq[i].end(), zero_value);
     }
 
-    // Update extrinsic output for edge equality constraints based on messages from subtour elimination constraints
-    for (int i = 0; i < rSubtourConstraints2EdgeEcM.size(); i++)
-    {
-        transform(rSubtourConstraints2EdgeEcM[i].begin(),
-                  rSubtourConstraints2EdgeEcM[i].end(), ExtrinsicOutputEdgeEc.begin(),
-                  ExtrinsicOutputEdgeEc.begin(), plus<impalib_type>());
+    // Update extrinsic_ output for edge equality constraints based on messages from subtour elimination constraints
+    for (int i = 0; i < subtour2edge.size(); i++) {
+        transform(subtour2edge[i].begin(), subtour2edge[i].end(), extrinsic.begin(), extrinsic.begin(), plus<impalib_type>());
     }
 }
 
 /**
  * Calculate output intrinsic messages of edge equality constraint for TSP
  *
- * @param[in] rCostEdgeVariable: cost of each edge equality constraint
- * 
+ * @param[in] costs: cost of each edge equality constraint
+ *
  */
 
-void OutputsTsp::update_intrinsic(vector<impalib_type> &rCostEdgeVariable)
-{
-
-    // Calculate intrinsic output for edge equality constraints by adding extrinsic output for edge equality constraints to cost edge variable
-    transform(ExtrinsicOutputEdgeEc.begin(), ExtrinsicOutputEdgeEc.end(), rCostEdgeVariable.begin(),
-              IntrinsicOutputEdgeEc.begin(), plus<impalib_type>());
+void OutputsTsp::update_intrinsic(vector<impalib_type> &costs) {
+    // Calculate intrinsic output for edge equality constraints by adding extrinsic_ output for edge equality constraints to cost edge variable
+    transform(extrinsic.begin(), extrinsic.end(), costs.begin(), intrinsic.begin(), plus<impalib_type>());
 }

--- a/include/impalib/input_output.hpp
+++ b/include/impalib/input_output.hpp
@@ -71,7 +71,6 @@ InputsKcMwm::InputsKcMwm(const int N_DEPARTMENTS, const int N_TEAMS, const int N
     : numDepartments_(N_DEPARTMENTS), numTeams_(N_TEAMS), numProjects_(N_PROJECTS),
       maxSizeNonzeroWeights_(MAX_SIZE_NON_ZERO_WEIGHTS)
 {
-    // Reserve memory for vectors based on provided sizes
     TeamsWeightsPerDepartment.reserve(numDepartments_);
     NonZeroWeightIndices.reserve(numDepartments_);
     RewardProject.reserve(numProjects_);
@@ -113,26 +112,21 @@ void InputsKcMwm::process_inputs(const impalib_type *pREWARD_TEAM_PY, impalib_ty
     // Copy reward values for each team and maximum states per department
     copy(pREWARD_TEAM_PY, pREWARD_TEAM_PY + numTeams_, back_inserter(RewardTeam));
     copy(pMAX_STATE_PY, pMAX_STATE_PY + numDepartments_, back_inserter(MaxState));
-    
-    // Iterate over each department
+
     for (int department_index = 0; department_index < numDepartments_; department_index++)
     {   
         // Populate NonZeroWeightIndices for the department
         NonZeroWeightIndices.push_back(vector<int>(pNON_ZERO_WEIGHT_INDICES_SIZES_PY[department_index], 0));
-        // Copy transition model values for the department
         copy(pTransition_model_py + numTeams_ * department_index,
              pTransition_model_py + numTeams_ * (department_index + 1), Team2KnapsackM[department_index].begin());
-        // Copy teams weights per department
         copy(pTEAMS_WEIGHTS_PER_DEPARTMENT_PY + numTeams_ * department_index,
              pTEAMS_WEIGHTS_PER_DEPARTMENT_PY + numTeams_ * (department_index + 1),
              TeamsWeightsPerDepartment[department_index].begin());
-        // Copy NonZeroWeightIndices for the department
         copy(p_NON_ZERO_WEIGHT_INDICES_PY + maxSizeNonzeroWeights_ * department_index,
              p_NON_ZERO_WEIGHT_INDICES_PY + pNON_ZERO_WEIGHT_INDICES_SIZES_PY[department_index]
                  + maxSizeNonzeroWeights_ * department_index,
              NonZeroWeightIndices[department_index].begin());
     }
-    // Iterate over each project
     for (int project_index = 0; project_index < numProjects_; project_index++)
     {
         // Copy reward values for each project-team combination
@@ -156,13 +150,10 @@ void InputsKcMwm::process_inputs(const impalib_type *pREWARD_TEAM_PY, impalib_ty
 OutputsKcMwm::OutputsKcMwm(const int N_DEPARTMENTS, const int N_TEAMS, const int N_PROJECTS)
     : numDepartments_(N_DEPARTMENTS), numTeams_(N_TEAMS), numProjects_(N_PROJECTS)
 {
-
-    // Reserve memory for extrinsic output per team and initialize with zero values
     ExtrinsicOutputTeam.reserve(numTeams_);
     ExtrinsicOutputTeam.resize(numTeams_);
     fill(ExtrinsicOutputTeam.begin(), ExtrinsicOutputTeam.begin() + numTeams_, zero_value);
 
-    // Reserve memory for intrinsic output per project-team combination and initialize with zero values
     IntrinsicOutMwm.reserve(numProjects_ * numTeams_);
     IntrinsicOutMwm.resize(numProjects_ * numTeams_);
     fill(IntrinsicOutMwm.begin(), IntrinsicOutMwm.begin() + numProjects_ * numTeams_, zero_value);
@@ -181,10 +172,8 @@ void OutputsKcMwm::intrinsic_out_mwm_update(vector<vector<impalib_type>> &rOric2
                                             vector<vector<impalib_type>> &rProject2EqConstraintM,
                                             vector<vector<impalib_type>> &rRewardProject)
 {
-    // Iterate over projects
     for (int project_index = 0; project_index < rRewardProject.size(); project_index++)
     {
-        // Iterate over teams
         for (int team_index = 0; team_index < rRewardProject[project_index].size(); team_index++)
         {
             // Calculate the intrinsic output for the project-team combination
@@ -206,11 +195,8 @@ void OutputsKcMwm::intrinsic_out_mwm_update(vector<vector<impalib_type>> &rOric2
 void OutputsKcMwm::extrinsic_output_team_update(vector<vector<impalib_type>> &rExtrinsicOutputDepartment,
                                                 vector<impalib_type>         &rOric2TeamM)
 {
-
-    // Copy the values from rOric2TeamM to ExtrinsicOutputTeam
     copy(rOric2TeamM.begin(), rOric2TeamM.end(), ExtrinsicOutputTeam.begin());
 
-    // Iterate over departments
     for (int department_index = 0; department_index < rExtrinsicOutputDepartment.size(); department_index++)
     {
         // Calculate rExtrinsicOutputDepartment by adding rOric2TeamM
@@ -358,11 +344,9 @@ void OutputsTsp::extrinsic_output_edge_ec_relaxed_graph_update(
     vector<vector<impalib_type>> &rDegreeConstraint2EqConstraintM)
 {
 
-    // Iterate over each edge variable index
     for (int edge_variable_index = 0; edge_variable_index < rDegreeConstraint2EqConstraintM.size();
          edge_variable_index++)
     {
-         // Calculate extrinsic output for the edge equality constraints
         ExtrinsicOutputEdgeEc[edge_variable_index] =
             accumulate(rDegreeConstraint2EqConstraintM[edge_variable_index].begin(),
                        rDegreeConstraint2EqConstraintM[edge_variable_index].end(), zero_value);

--- a/include/impalib/input_output.hpp
+++ b/include/impalib/input_output.hpp
@@ -172,7 +172,7 @@ class InputsTsp {
 
     void process_inputs(const int *, const impalib_type *, const impalib_type *, const impalib_type *, const impalib_type *);  ///< process inputs of TSP graphical model
 
-    InputsTsp(const int NUM_NODES, const int NUM_EDGE_VARIABLES);  ///< constructor
+    InputsTsp(int NUM_NODES, int NUM_EDGE_VARIABLES);  ///< constructor
 };
 
 /**

--- a/include/impalib/input_output.hpp
+++ b/include/impalib/input_output.hpp
@@ -46,9 +46,9 @@ private:
 public:
     vector<impalib_type> ExtrinsicOutputTeam; ///< extrinsic output of team equality constraints
     vector<impalib_type> IntrinsicOutMwm; ///< intrinsic outputs of project equality constraint 
-    void                 intrinsic_out_mwm_update(vector<vector<impalib_type>> &, vector<vector<impalib_type>> &,
-                                                  vector<vector<impalib_type>> &); ///< calculate intrinsic outputs of project equality constraints
-    void                 extrinsic_output_team_update(vector<vector<impalib_type>> &, vector<impalib_type> &); ///< calculate extrinsic output of team equality constraints
+    void update_intrinsic(vector<vector<impalib_type>> &rOric2EqConstraintM, vector<vector<impalib_type>> &rProject2EqConstraintM,
+                                                  vector<vector<impalib_type>> &rRewardProject); ///< calculate intrinsic outputs of project equality constraints
+    void update_extrinsic(vector<vector<impalib_type>> &rExtrinsicOutputDepartment, vector<impalib_type> &rOric2TeamM); ///< calculate extrinsic output of team equality constraints
     OutputsKcMwm(const int N_DEPARTMENTS, const int N_TEAMS, const int N_PROJECTS); ///< constructor
 };
 
@@ -168,7 +168,7 @@ OutputsKcMwm::OutputsKcMwm(const int N_DEPARTMENTS, const int N_TEAMS, const int
  * 
  */
 
-void OutputsKcMwm::intrinsic_out_mwm_update(vector<vector<impalib_type>> &rOric2EqConstraintM,
+void OutputsKcMwm::update_intrinsic(vector<vector<impalib_type>> &rOric2EqConstraintM,
                                             vector<vector<impalib_type>> &rProject2EqConstraintM,
                                             vector<vector<impalib_type>> &rRewardProject)
 {
@@ -192,7 +192,7 @@ void OutputsKcMwm::intrinsic_out_mwm_update(vector<vector<impalib_type>> &rOric2
  * 
  */
 
-void OutputsKcMwm::extrinsic_output_team_update(vector<vector<impalib_type>> &rExtrinsicOutputDepartment,
+void OutputsKcMwm::update_extrinsic(vector<vector<impalib_type>> &rExtrinsicOutputDepartment,
                                                 vector<impalib_type>         &rOric2TeamM)
 {
     copy(rOric2TeamM.begin(), rOric2TeamM.end(), ExtrinsicOutputTeam.begin());
@@ -254,10 +254,10 @@ private:
 public:
     vector<impalib_type> ExtrinsicOutputEdgeEc; ///< extrinsic output of edge equality constraint
     vector<impalib_type> IntrinsicOutputEdgeEc; ///< intrinsic output of edge equality constraint
-    void                 extrinsic_output_edge_ec_relaxed_graph_update(vector<vector<impalib_type>> &); ///< calculate extrinsic output of edge equality constraint for a relaxed TSP
-    void                 extrinsic_output_edge_ec_augmented_graph_update(vector<vector<impalib_type>> &,
-                                                                         vector<vector<impalib_type>> &); ///< calculate extrinsic output of edge equality constraint for augmented TSP
-    void                 intrinsic_output_edge_ec_update(vector<impalib_type> &); ///< calculate intrinsic output of edge equality constraint for augmented TSP
+    void update_extrinsic_relaxed(vector<vector<impalib_type>> &rDegreeConstraint2EqConstraintM); ///< calculate extrinsic output of edge equality constraint for a relaxed TSP
+    void update_extrinsic_augmented(vector<vector<impalib_type>> &rDegreeConstraint2EqConstraintM,
+                                                                         vector<vector<impalib_type>> &rSubtourConstraints2EdgeEcM); ///< calculate extrinsic output of edge equality constraint for augmented TSP
+    void update_intrinsic(vector<impalib_type> &rCostEdgeVariable); ///< calculate intrinsic output of edge equality constraint for augmented TSP
     OutputsTsp(const int NUM_NODES, const int NUM_EDGE_VARIABLES); ///< constructor
 };
 
@@ -340,7 +340,7 @@ void InputsTsp::process_inputs(const int *pEDGE_CONNECTIONS_PY, const impalib_ty
  * 
  */
 
-void OutputsTsp::extrinsic_output_edge_ec_relaxed_graph_update(
+void OutputsTsp::update_extrinsic_relaxed(
     vector<vector<impalib_type>> &rDegreeConstraint2EqConstraintM)
 {
 
@@ -360,7 +360,7 @@ void OutputsTsp::extrinsic_output_edge_ec_relaxed_graph_update(
  * 
  */
 
-void OutputsTsp::extrinsic_output_edge_ec_augmented_graph_update(
+void OutputsTsp::update_extrinsic_augmented(
     vector<vector<impalib_type>> &rDegreeConstraint2EqConstraintM,
     vector<vector<impalib_type>> &rSubtourConstraints2EdgeEcM)
 {
@@ -389,7 +389,7 @@ void OutputsTsp::extrinsic_output_edge_ec_augmented_graph_update(
  * 
  */
 
-void OutputsTsp::intrinsic_output_edge_ec_update(vector<impalib_type> &rCostEdgeVariable)
+void OutputsTsp::update_intrinsic(vector<impalib_type> &rCostEdgeVariable)
 {
 
     // Calculate intrinsic output for edge equality constraints by adding extrinsic output for edge equality constraints to cost edge variable

--- a/include/impalib/input_output.hpp
+++ b/include/impalib/input_output.hpp
@@ -27,10 +27,10 @@ public:
     vector<int>                  MaxState; ///< vector of capacities of departments
     vector<vector<int>>          NonZeroWeightIndices; ///< indices of non-zero weights per each department
 
-    void process_inputs(const impalib_type *, impalib_type *, const int *, const int *, const int *,
+    void process_inputs(const impalib_type *, const impalib_type *, const int *, const int *, const int *,
                         const impalib_type *, const int *); ///< process input of graphical model
 
-    InputsKcMwm(const int N_DEPARTMENTS, const int N_TEAMS, const int N_PROJECTS, const int MAX_SIZE_NON_ZERO_WEIGHTS); ///< constructor
+    InputsKcMwm(int N_DEPARTMENTS, int N_TEAMS, int N_PROJECTS, int MAX_SIZE_NON_ZERO_WEIGHTS); ///< constructor
 };
 
 /**
@@ -46,10 +46,10 @@ private:
 public:
     vector<impalib_type> ExtrinsicOutputTeam; ///< extrinsic output of team equality constraints
     vector<impalib_type> IntrinsicOutMwm; ///< intrinsic outputs of project equality constraint 
-    void update_intrinsic(vector<vector<impalib_type>> &rOric2EqConstraintM, vector<vector<impalib_type>> &rProject2EqConstraintM,
-                                                  vector<vector<impalib_type>> &rRewardProject); ///< calculate intrinsic outputs of project equality constraints
-    void update_extrinsic(vector<vector<impalib_type>> &rExtrinsicOutputDepartment, vector<impalib_type> &rOric2TeamM); ///< calculate extrinsic output of team equality constraints
-    OutputsKcMwm(const int N_DEPARTMENTS, const int N_TEAMS, const int N_PROJECTS); ///< constructor
+    void update_intrinsic(const vector<vector<impalib_type>> &rOric2EqConstraintM, const vector<vector<impalib_type>> &rProject2EqConstraintM,
+                                                  const vector<vector<impalib_type>> &rRewardProject); ///< calculate intrinsic outputs of project equality constraints
+    void update_extrinsic(const vector<vector<impalib_type>> &rExtrinsicOutputDepartment, const vector<impalib_type> &rOric2TeamM); ///< calculate extrinsic output of team equality constraints
+    OutputsKcMwm(int N_DEPARTMENTS, int N_TEAMS, int N_PROJECTS); ///< constructor
 };
 
 /**
@@ -103,7 +103,7 @@ InputsKcMwm::InputsKcMwm(const int N_DEPARTMENTS, const int N_TEAMS, const int N
  * 
  */
 
-void InputsKcMwm::process_inputs(const impalib_type *pREWARD_TEAM_PY, impalib_type *pTransition_model_py,
+void InputsKcMwm::process_inputs(const impalib_type *pREWARD_TEAM_PY, const impalib_type *pTransition_model_py,
                                  const int *pTEAMS_WEIGHTS_PER_DEPARTMENT_PY,
                                  const int *pNON_ZERO_WEIGHT_INDICES_SIZES_PY, const int *p_NON_ZERO_WEIGHT_INDICES_PY,
                                  const impalib_type *pREWARD_PROJECT_PY, const int *pMAX_STATE_PY)
@@ -162,9 +162,9 @@ OutputsKcMwm::OutputsKcMwm(const int N_DEPARTMENTS, const int N_TEAMS, const int
  * 
  */
 
-void OutputsKcMwm::update_intrinsic(vector<vector<impalib_type>> &rOric2EqConstraintM,
-                                            vector<vector<impalib_type>> &rProject2EqConstraintM,
-                                            vector<vector<impalib_type>> &rRewardProject)
+void OutputsKcMwm::update_intrinsic(const vector<vector<impalib_type>> &rOric2EqConstraintM,
+                                    const vector<vector<impalib_type>> &rProject2EqConstraintM,
+                                    const vector<vector<impalib_type>> &rRewardProject)
 {
     for (int i = 0; i < rRewardProject.size(); i++)  // over projects
     {
@@ -186,14 +186,13 @@ void OutputsKcMwm::update_intrinsic(vector<vector<impalib_type>> &rOric2EqConstr
  * 
  */
 
-void OutputsKcMwm::update_extrinsic(vector<vector<impalib_type>> &rExtrinsicOutputDepartment,
-                                                vector<impalib_type>         &rOric2TeamM)
+void OutputsKcMwm::update_extrinsic(const vector<vector<impalib_type>> &rExtrinsicOutputDepartment,
+                                                const vector<impalib_type>         &rOric2TeamM)
 {
-    copy(rOric2TeamM.begin(), rOric2TeamM.end(), ExtrinsicOutputTeam.begin());
+    ExtrinsicOutputTeam = rOric2TeamM;
 
     for (int i = 0; i < rExtrinsicOutputDepartment.size(); i++)
     {
-        // Calculate rExtrinsicOutputDepartment by adding rOric2TeamM
         transform(rExtrinsicOutputDepartment[i].begin(),
                   rExtrinsicOutputDepartment[i].end(), ExtrinsicOutputTeam.begin(),
                   ExtrinsicOutputTeam.begin(), std::plus<impalib_type>());
@@ -217,7 +216,7 @@ public:
     vector<vector<impalib_type>> EdgeDegreeConstraintCost; ///< cost matrix represented as num_edges x num_nodes to facilitate message updates
     vector<vector<impalib_type>> EdgeEc2DegreeConstraintM; ///< messages from edge equality constraint to degree constraint
 
-    void process_inputs(const int *, const impalib_type *, const impalib_type *, impalib_type *, const impalib_type *); ///< process inputs of TSP graphical model
+    void process_inputs(const int *, const impalib_type *, const impalib_type *, const impalib_type *, const impalib_type *); ///< process inputs of TSP graphical model
 
     InputsTsp(const int NUM_NODES, const int NUM_EDGE_VARIABLES); ///< constructor
 };
@@ -291,7 +290,7 @@ OutputsTsp::OutputsTsp(const int NUM_NODES, const int NUM_EDGE_VARIABLES)
  */
 
 void InputsTsp::process_inputs(const int *pEDGE_CONNECTIONS_PY, const impalib_type *pCOST_EDGE_VARIABLE_PY,
-                               const impalib_type *pCOST_MATRIX_PY, impalib_type *pEdge_ec_to_degree_constraint_m_py,
+                               const impalib_type *pCOST_MATRIX_PY, const impalib_type *pEdge_ec_to_degree_constraint_m_py,
                                const impalib_type *pEDGE_DEGREE_CONSTRAINT_COST_PY)
 {
 

--- a/include/impalib/knapsack.hpp
+++ b/include/impalib/knapsack.hpp
@@ -53,15 +53,9 @@ public:
  */
 
 Knapsack::Knapsack(const int N_DEPARTMENTS, const int N_TEAMS, const bool FILT_FLAG, const impalib_type ALPHA)
-    : numDepartments_(N_DEPARTMENTS), numTeams_(N_TEAMS), filteringFlag_(FILT_FLAG), alpha_(ALPHA)
+    : numDepartments_(N_DEPARTMENTS), numTeams_(N_TEAMS), filteringFlag_(FILT_FLAG), alpha_(ALPHA),
+      extrinsicOutputDepartmentOld_(numDepartments_, vector<impalib_type>(numTeams_, 0))
 {
-
-    // Initialize extrinsic output department
-    extrinsicOutputDepartmentOld_.reserve(numDepartments_);
-    for (int i = 0; i < numDepartments_; i++)
-    {
-        extrinsicOutputDepartmentOld_.push_back(vector<impalib_type>(numTeams_, zero_value));
-    }
 };
 
 /**

--- a/include/impalib/knapsack.hpp
+++ b/include/impalib/knapsack.hpp
@@ -11,30 +11,29 @@
 /**
  * Represents a class for the Knapsack constraint for Knapsack-MWM problem
  */
-class Knapsack
-{
-private:
-    int                          numDepartments_; ///< number of departments
-    int                          numTeams_; ///< number of teams
-    bool                         filteringFlag_; ///< filtering flag
-    impalib_type                 alpha_; ///< filtering parameter
-    vector<vector<impalib_type>> extrinsicOutputDepartmentOld_; ///< messages from departments to teams equality constraint before filtering
+class Knapsack {
+   private:
+    int numDepartments_;                         ///< number of departments
+    int numTeams_;                               ///< number of teams
+    bool filteringFlag_;                         ///< filtering flag
+    impalib_type alpha_;                         ///< filtering parameter
+    vector<vector<impalib_type>> extrinsic_old;  ///< messages from departments to teams equality constraint before filtering
 
-public:
+   public:
     vector<vector<impalib_type>> forward(int, int, const vector<int> &, const int *, const vector<int> &,
-                 const vector<vector<impalib_type>> &); ///< forward pass of forward-backward algorithm
+                                         const vector<vector<impalib_type>> &);  ///< forward pass of forward-backward algorithm
 
     vector<vector<impalib_type>> backward(int, int, const vector<int> &, const int *, const vector<int> &,
-                  const vector<vector<impalib_type>> &); ///< backward pass of forward-backward algorithm
+                                          const vector<vector<impalib_type>> &);  ///< backward pass of forward-backward algorithm
 
-    vector<impalib_type> extrinsic_output_department_lhs(const vector<int> &, const vector<vector<impalib_type>> &,
-                                         const vector<vector<impalib_type>> &, int, const vector<vector<impalib_type>> &, int); ///< extrinsic output of department constraint
+    vector<impalib_type> extrinsic_output_department_lhs(const vector<int> &, const vector<vector<impalib_type>> &, const vector<vector<impalib_type>> &, int, const vector<vector<impalib_type>> &,
+                                                         int);  ///< extrinsic_ output of department constraint
 
-    void team_to_knapsack_update(const vector<vector<int>> &, vector<vector<impalib_type>> &, const vector<impalib_type> &,
-                                 const vector<vector<impalib_type>> &, const vector<impalib_type> &); ///< calculate messages from teams to knapsack constraints
-    void process_extrinsic_output_department(int, int, const vector<impalib_type> &, vector<impalib_type> &); ///< perform filtering (if needed) on messages from departments to teams
+    void team_to_knapsack_update(const vector<vector<int>> &, vector<vector<impalib_type>> &, const vector<impalib_type> &, const vector<vector<impalib_type>> &,
+                                 const vector<impalib_type> &);                                                ///< calculate messages from teams to knapsack constraints
+    void process_extrinsic_output_department(int, int, const vector<impalib_type> &, vector<impalib_type> &);  ///< perform filtering (if needed) on messages from departments to teams
 
-    Knapsack(int N_DEPARTMENTS, int N_TEAMS, bool FILT_FLAG, impalib_type ALPHA); ///< constructor
+    Knapsack(int N_DEPARTMENTS, int N_TEAMS, bool FILT_FLAG, impalib_type ALPHA);  ///< constructor
 };
 
 /**
@@ -48,318 +47,230 @@ public:
  * @param[out] numTeams_: N_TEAMS
  * @param[out] filteringFlag_: FILT_FLAG
  * @param[out] alpha_: ALPHA
- * 
+ *
  */
 
 Knapsack::Knapsack(const int N_DEPARTMENTS, const int N_TEAMS, const bool FILT_FLAG, const impalib_type ALPHA)
-    : numDepartments_(N_DEPARTMENTS), numTeams_(N_TEAMS), filteringFlag_(FILT_FLAG), alpha_(ALPHA),
-      extrinsicOutputDepartmentOld_(numDepartments_, vector<impalib_type>(numTeams_, 0))
-{
-};
+    : numDepartments_(N_DEPARTMENTS), numTeams_(N_TEAMS), filteringFlag_(FILT_FLAG), alpha_(ALPHA), extrinsic_old(numDepartments_, vector<impalib_type>(numTeams_, 0)){};
 
 /**
  * Perform forward pass for a department (trellis of knapsack) in Forward-Backward algorithm for the Knapsack-MWM problem
  *
- * @param[in] department_index: index of department (knapsack constraint)
- * @param[in] max_state_department: capacity of department under 
- * @param[in] rNonZeroWeightIndices: indices where connections are present between teams and departments
- * @param[in] pNON_ZERO_WEIGHT_INDICES_SIZES_PY: sizes of non-zero weight indices
+ * @param[in] idx: index of department (knapsack constraint)
+ * @param[in] capacity: capacity of department under
+ * @param[in] idx_nonzero: indices where connections are present between teams and departments
+ * @param[in] idx_nonzero_sizes: sizes of non-zero weight indices
  * @param[in] rTeamsWeightsPerDepartment: weights of teams for the department under investigation
- * @param[in] rTeam2KnapsackM: messages from teams to knapsack constraints
+ * @param[in] team2knapsack: messages from teams to knapsack constraints
  * @param[out] rStageForwardMessages: calculated forward messages on the trellis
- * 
+ *
  */
 
-vector<vector<impalib_type>> Knapsack::forward(const int department_index,
-                       const int max_state_department, const vector<int> &rNonZeroWeightIndices,
-                       const int *pNON_ZERO_WEIGHT_INDICES_SIZES_PY, const vector<int> &rTeamWeights,
-                       const vector<vector<impalib_type>> &rTeam2KnapsackM)
-{
+vector<vector<impalib_type>> Knapsack::forward(const int idx, const int capacity, const vector<int> &idx_nonzero, const int *idx_nonzero_sizes, const vector<int> &weights,
+                                               const vector<vector<impalib_type>> &team2knapsack) {
     vector<int>::const_iterator upper;
-    vector<vector<impalib_type>> rStageForwardMessages(numTeams_ + 1, vector<impalib_type>(max_state_department + 1, zero_value));
+    vector<vector<impalib_type>> forward(numTeams_ + 1, vector<impalib_type>(capacity + 1, zero_value));
 
     // Initialize initial forward messages
-    vector<impalib_type> initial_forward_messages(max_state_department + 1, zero_value);
-    fill(initial_forward_messages.begin() + 1, initial_forward_messages.end(), value_inf);
+    vector<impalib_type> forward0(capacity + 1, zero_value);
+    fill(forward0.begin() + 1, forward0.end(), value_inf);
 
     // Assign initial forward messages to the first stage
-    rStageForwardMessages[0] = initial_forward_messages;
+    forward[0] = forward0;
 
     // If the first non-zero weight index is not zero, assign initial messages to subsequent stages
-    if (rNonZeroWeightIndices[0] != 0)
-    {
-        for (int j = 0; j < rNonZeroWeightIndices[0]; j++)
-        {
-            rStageForwardMessages[j + 1] = initial_forward_messages;
+    if (idx_nonzero[0] != 0) {
+        for (int j = 0; j < idx_nonzero[0]; j++) {
+            forward[j + 1] = forward0;
         }
     }
 
-    for (int l = 0; l < pNON_ZERO_WEIGHT_INDICES_SIZES_PY[department_index]; l++)
-    {
-        int t = rNonZeroWeightIndices[l];
-        for (int a = 0; a <= max_state_department; a++)
-        {
-            if (a - rTeamWeights[t] >= 0
-                && (!(t == 0 && a != rTeamWeights[t])))
-            {
+    for (int l = 0; l < idx_nonzero_sizes[idx]; l++) {
+        int t = idx_nonzero[l];
+        for (int a = 0; a <= capacity; a++) {
+            if (a - weights[t] >= 0 && (!(t == 0 && a != weights[t]))) {
                 // Update forward messages
-                rStageForwardMessages[t + 1][a] =
-                    min(initial_forward_messages[a],
-                        initial_forward_messages[a - rTeamWeights[t]]
-                            + rTeam2KnapsackM[department_index][t]);
-            }
-            else
-            {
-                rStageForwardMessages[t + 1][a] = initial_forward_messages[a];
+                forward[t + 1][a] = min(forward0[a], forward0[a - weights[t]] + team2knapsack[idx][t]);
+            } else {
+                forward[t + 1][a] = forward0[a];
             }
         }
 
         // Update initial forward messages
-        initial_forward_messages = rStageForwardMessages[t + 1];
+        forward0 = forward[t + 1];
 
         // Handle the case when non-zero weight indices are not equal to the number of teams
-        if (rNonZeroWeightIndices.size() != numTeams_)
-        {
-            if (!binary_search(rNonZeroWeightIndices.begin(),
-                               rNonZeroWeightIndices.end(), t + 1))
-            {
-                if (t + 1 >= rNonZeroWeightIndices.back() && t + 1 < numTeams_)
-                {
-                    for (int j = t + 1; j < numTeams_; j++)
-                    {
-                        rStageForwardMessages[j + 1] = initial_forward_messages;
+        if (idx_nonzero.size() != numTeams_) {
+            if (!binary_search(idx_nonzero.begin(), idx_nonzero.end(), t + 1)) {
+                if (t + 1 >= idx_nonzero.back() && t + 1 < numTeams_) {
+                    for (int j = t + 1; j < numTeams_; j++) {
+                        forward[j + 1] = forward0;
                     }
-                }
-                else if (t + 1 < rNonZeroWeightIndices.back())
-                {
-                    upper             = upper_bound(rNonZeroWeightIndices.begin(),
-                                                    rNonZeroWeightIndices.end(), t);
-                    size_t next_index = upper - rNonZeroWeightIndices.begin();
-                    for (int j = t + 1; j < rNonZeroWeightIndices[next_index]; j++)
-                    {
-                        rStageForwardMessages[j + 1] = initial_forward_messages;
+                } else if (t + 1 < idx_nonzero.back()) {
+                    upper = upper_bound(idx_nonzero.begin(), idx_nonzero.end(), t);
+                    size_t next_index = upper - idx_nonzero.begin();
+                    for (int j = t + 1; j < idx_nonzero[next_index]; j++) {
+                        forward[j + 1] = forward0;
                     }
                 }
             }
         }
     }
-    return rStageForwardMessages;
+    return forward;
 }
 
 /**
  * Perform backward pass for a department (trellis of knapsack) in Forward-Backward algorithm for the Knapsack-MWM problem
  *
- * @param[in] department_index: index of department (knapsack constraint)
- * @param[in] max_state_department: capacity of department under 
- * @param[in] rNonZeroWeightIndices: indices where connections are present between teams and departments
- * @param[in] pNON_ZERO_WEIGHT_INDICES_SIZES_PY: sizes of non-zero weight indices
- * @param[in] rTeamsWeightsPerDepartment: weights of teams for the department under investigation
- * @param[in] rTeam2KnapsackM: messages from teams to knapsack constraints
+ * @param[in] idx: index of department (knapsack constraint)
+ * @param[in] capacity: capacity of department under
+ * @param[in] idx_nonzero: indices where connections are present between teams and departments
+ * @param[in] idx_nonzero_sizes: sizes of non-zero weight indices
+ * @param[in] weights: weights of teams for the department under investigation
+ * @param[in] team2knapsack: messages from teams to knapsack constraints
  * @param[out] rStageBackwardMessages: calculated backward messages on the trellis
- * 
+ *
  */
 
-vector<vector<impalib_type>> Knapsack::backward(const int department_index,
-                        const int max_state_department, const vector<int> &rNonZeroWeightIndices,
-                        const int *pNON_ZERO_WEIGHT_INDICES_SIZES_PY, const vector<int> &rTeamsWeightsPerDepartment,
-                        const vector<vector<impalib_type>> &rTeam2KnapsackM)
-{
-
+vector<vector<impalib_type>> Knapsack::backward(const int idx, const int capacity, const vector<int> &idx_nonzero, const int *idx_nonzero_sizes, const vector<int> &weights,
+                                                const vector<vector<impalib_type>> &team2knapsack) {
     vector<int>::const_iterator upper;
-    vector<vector<impalib_type>> rStageBackwardMessages(numTeams_ + 1, vector<impalib_type>(max_state_department + 1, zero_value));
+    vector<vector<impalib_type>> backward(numTeams_ + 1, vector<impalib_type>(capacity + 1, zero_value));
 
     // Initialize initial backward messages
-    vector<impalib_type>  initial_backward_messages(max_state_department + 1, zero_value);
+    vector<impalib_type> backward0(capacity + 1, zero_value);
 
     // Assign initial backward messages to the last stage
-    rStageBackwardMessages[numTeams_] = initial_backward_messages;
+    backward[numTeams_] = backward0;
 
     // If the last non-zero weight index is not numTeams_ - 1, assign initial messages to previous stages
-    if (rNonZeroWeightIndices[pNON_ZERO_WEIGHT_INDICES_SIZES_PY[department_index] - 1]
-        != numTeams_ - 1)
-    {
-        for (int j = numTeams_ - 1; j > rNonZeroWeightIndices[0]; j--)
-        {
-            rStageBackwardMessages[j] = initial_backward_messages;
+    if (idx_nonzero[idx_nonzero_sizes[idx] - 1] != numTeams_ - 1) {
+        for (int j = numTeams_ - 1; j > idx_nonzero[0]; j--) {
+            backward[j] = backward0;
         }
     }
 
-    for (int l = pNON_ZERO_WEIGHT_INDICES_SIZES_PY[department_index] - 1; l >= 0; l--)
-    {
-        int t = rNonZeroWeightIndices[l];
-        for (int a = 0; a <= max_state_department; a++)
-        {
-            if ((t > 0 && a + rTeamsWeightsPerDepartment[t] <= max_state_department)
-                || (a == 0 && t == 0))
-            {
+    for (int l = idx_nonzero_sizes[idx] - 1; l >= 0; l--) {
+        int t = idx_nonzero[l];
+        for (int a = 0; a <= capacity; a++) {
+            if ((t > 0 && a + weights[t] <= capacity) || (a == 0 && t == 0)) {
                 // Update backward messages
-                rStageBackwardMessages[t][a] =
-                    min(initial_backward_messages[a],
-                        initial_backward_messages[a + rTeamsWeightsPerDepartment[t]]
-                            + rTeam2KnapsackM[department_index][t]);
-            }
-            else
-            {
-                rStageBackwardMessages[t][a] = initial_backward_messages[a];
+                backward[t][a] = min(backward0[a], backward0[a + weights[t]] + team2knapsack[idx][t]);
+            } else {
+                backward[t][a] = backward0[a];
             }
         }
 
         // Update initial backward messages
-        initial_backward_messages = rStageBackwardMessages[t];
+        backward0 = backward[t];
 
         // Handle the case when non-zero weight indices are not equal to the number of teams
-        if (pNON_ZERO_WEIGHT_INDICES_SIZES_PY[department_index] - 1 != numTeams_)
-        {
-            if (!binary_search(rNonZeroWeightIndices.begin(),
-                               rNonZeroWeightIndices.end(), t - 1))
-            {
-                if ((t - 1 <= rNonZeroWeightIndices[0]) && t - 1 >= 0)
-                {
-                    for (int j = t - 1; j >= 0; j--)
-                    {
-                        rStageBackwardMessages[j] = initial_backward_messages;
+        if (idx_nonzero_sizes[idx] - 1 != numTeams_) {
+            if (!binary_search(idx_nonzero.begin(), idx_nonzero.end(), t - 1)) {
+                if ((t - 1 <= idx_nonzero[0]) && t - 1 >= 0) {
+                    for (int j = t - 1; j >= 0; j--) {
+                        backward[j] = backward0;
                     }
-                }
-                else if (t - 1 > rNonZeroWeightIndices[0])
-                {
-                    upper             = upper_bound(rNonZeroWeightIndices.begin(),
-                                                    rNonZeroWeightIndices.end(), t - 1);
-                    size_t next_index = upper - rNonZeroWeightIndices.begin();
-                    for (int j = t - 1; j > rNonZeroWeightIndices[next_index - 1]; j--)
-                    {
-                        rStageBackwardMessages[j] = initial_backward_messages;
+                } else if (t - 1 > idx_nonzero[0]) {
+                    upper = upper_bound(idx_nonzero.begin(), idx_nonzero.end(), t - 1);
+                    size_t next_index = upper - idx_nonzero.begin();
+                    for (int j = t - 1; j > idx_nonzero[next_index - 1]; j--) {
+                        backward[j] = backward0;
                     }
                 }
             }
         }
     }
-    return rStageBackwardMessages;
+    return backward;
 }
 
 /**
  * Calculate messages from departments to teams after obtaining forward and backward messages on a knapsack trellis following Forward-Backward algorithm for the Knapsack-MWM problem
  *
- * @param[in] rTeamsWeightsPerDepartment: weights of teams for the department under investigation
- * @param[in] rStageForwardMessages: calculated forward messages on the trellis
- * @param[in] rTeam2KnapsackM: messages from teams to knapsack constraints
- * @param[in] department_index: index of department (knapsack constraint)
- * @param[in] rStageBackwardMessages: calculated backward messages on the trellis
- * @param[in] max_state_department: capacity of department under 
- * @param[out] rExtrinsicOutputDepartment: extrinsic output messages from department to teams
- * 
+ * @param[in] weights: weights of teams for the department under investigation
+ * @param[in] forward: calculated forward messages on the trellis
+ * @param[in] team2knapsack: messages from teams to knapsack constraints
+ * @param[in] idx: index of department (knapsack constraint)
+ * @param[in] backward: calculated backward messages on the trellis
+ * @param[in] capacity: capacity of department under
+ * @param[out] rExtrinsicOutputDepartment: extrinsic_ output messages from department to teams
+ *
  */
 
-vector<impalib_type> Knapsack::extrinsic_output_department_lhs(const vector<int>          &rTeamsWeightsPerDepartment,
-                                               const vector<vector<impalib_type>> &rStageForwardMessages,
-                                               const vector<vector<impalib_type>> &rTeam2KnapsackM, const int department_index,
-                                               const vector<vector<impalib_type>> &rStageBackwardMessages,
-                                               const int                           max_state_department)
-{
-    vector<impalib_type> rExtrinsicOutput(rTeamsWeightsPerDepartment.size());
-    vector<impalib_type> metric_path_solid, metric_path_dash;
+vector<impalib_type> Knapsack::extrinsic_output_department_lhs(const vector<int> &weights, const vector<vector<impalib_type>> &forward, const vector<vector<impalib_type>> &team2knapsack,
+                                                               const int idx, const vector<vector<impalib_type>> &backward, const int capacity) {
+    vector<impalib_type> extrinsic(weights.size());
+    vector<impalib_type> solid, dash;
 
-    for (int i = 0; i < rTeamsWeightsPerDepartment.size(); i++)
-    {
-        metric_path_dash.clear();
-        metric_path_solid.clear();
+    for (int i = 0; i < weights.size(); i++) {
+        dash.clear();
+        solid.clear();
 
         // Check if the team has non-zero weight with the department
-        if (rTeamsWeightsPerDepartment[i] != 0)
-        {
+        if (weights[i] != 0) {
             // Calculate metric paths for solid (activated) and dashed (deactivated) states
-            if (i == 0)
-            {
-                metric_path_solid.push_back(
-                    rStageForwardMessages[i][i]
-                    + rStageBackwardMessages[i + 1][rTeamsWeightsPerDepartment[i]]
-                    + rTeam2KnapsackM[department_index][i]);
-                metric_path_dash.push_back(rStageForwardMessages[i][i]
-                                           + rStageBackwardMessages[i + 1][0]);
-            }
-            else
-            {
-                for (int j = 0; j <= max_state_department; j++)
-                {
-                    if (j + rTeamsWeightsPerDepartment[i] <= max_state_department)
-                    {
-                        metric_path_solid.push_back(
-                            rStageForwardMessages[i][j]
-                            + rStageBackwardMessages[i + 1]
-                                                    [j + rTeamsWeightsPerDepartment[i]]
-                            + rTeam2KnapsackM[department_index][i]);
+            if (i == 0) {
+                solid.push_back(forward[i][i] + backward[i + 1][weights[i]] + team2knapsack[idx][i]);
+                dash.push_back(forward[i][i] + backward[i + 1][0]);
+            } else {
+                for (int j = 0; j <= capacity; j++) {
+                    if (j + weights[i] <= capacity) {
+                        solid.push_back(forward[i][j] + backward[i + 1][j + weights[i]] + team2knapsack[idx][i]);
                     }
-                    metric_path_dash.push_back(rStageForwardMessages[i][j]
-                                               + rStageBackwardMessages[i + 1][j]);
+                    dash.push_back(forward[i][j] + backward[i + 1][j]);
                 }
             }
-            // Calculate extrinsic output for the department
-            rExtrinsicOutput[i] =
-                *min_element(metric_path_solid.begin(), metric_path_solid.end())
-                - *min_element(metric_path_dash.begin(), metric_path_dash.end())
-                - rTeam2KnapsackM[department_index][i];
-        }
-        else
-        {
-            rExtrinsicOutput[i] = zero_value;
+            // Calculate extrinsic_ output for the department
+            extrinsic[i] = *min_element(solid.begin(), solid.end()) - *min_element(dash.begin(), dash.end()) - team2knapsack[idx][i];
+        } else {
+            extrinsic[i] = zero_value;
         }
     }
-    return rExtrinsicOutput;
+    return extrinsic;
 }
 
 /**
  * Calculate messages from teams to departments for the Knapsack-MWM problem
  *
- * @param[in] rNonZeroWeightIndices: indices where connections are present between teams and departments
- * @param[in] rTeam2KnapsackM: messages from teams to knapsack constraints
- * @param[in] rRewardTeam: rewards of teams
- * @param[in] rExtrinsicOutputDepartment: extrinsic output messages from department to teams
- * @param[out] mORIC2Team: messages from ORIC to teams
- * 
+ * @param[in] idx_nonzero: indices where connections are present between teams and departments
+ * @param[in] team2knapsack: messages from teams to knapsack constraints
+ * @param[in] reward: rewards of teams
+ * @param[in] extrinsic: extrinsic_ output messages from department to teams
+ * @param[out] oric2team: messages from ORIC to teams
+ *
  */
 
-void Knapsack::team_to_knapsack_update(const vector<vector<int>>          &rNonZeroWeightIndices,
-                                       vector<vector<impalib_type>> &rTeam2KnapsackM, const vector<impalib_type> &rRewardTeam,
-                                       const vector<vector<impalib_type>> &rExtrinsicOutputDepartment,
-                                       const vector<impalib_type>         &mORIC2Team)
-{
-    for (int i = 0; i < rExtrinsicOutputDepartment.size(); i++)
-    {
+void Knapsack::team_to_knapsack_update(const vector<vector<int>> &idx_nonzero, vector<vector<impalib_type>> &team2knapsack, const vector<impalib_type> &reward,
+                                       const vector<vector<impalib_type>> &extrinsic, const vector<impalib_type> &oric2team) {
+    for (int i = 0; i < extrinsic.size(); i++) {
         // Create a list of remaining departments
-        vector<int> remaining_departments(numDepartments_);
-        iota(remaining_departments.begin(), remaining_departments.end(), 0);
+        vector<int> remaining(numDepartments_);
+        iota(remaining.begin(), remaining.end(), 0);
 
         // Get unique edge indices for the current department
-        vector<int> unique_edge_department(rNonZeroWeightIndices[i]);
-        remaining_departments.erase(remaining_departments.begin() + i);
+        vector<int> unique_edges(idx_nonzero[i]);
+        remaining.erase(remaining.begin() + i);
 
-        for (auto t : remaining_departments)
-        {
+        for (auto t : remaining) {
             // Calculate intersection of non-zero weight indices between the current department and other departments
-            vector<int>           intersection(numTeams_);
+            vector<int> intersection(numTeams_);
             vector<int>::iterator it;
-            it = set_intersection(rNonZeroWeightIndices[i].begin(),
-                                  rNonZeroWeightIndices[i].end(), rNonZeroWeightIndices[t].begin(),
-                                  rNonZeroWeightIndices[t].end(), intersection.begin());
+            it = set_intersection(idx_nonzero[i].begin(), idx_nonzero[i].end(), idx_nonzero[t].begin(), idx_nonzero[t].end(), intersection.begin());
             intersection.resize(it - intersection.begin());
 
             // Update team to knapsack constraint messages
-            for (auto l : intersection)
-            {
+            for (auto l : intersection) {
+                team2knapsack[i][l] = reward[l] + extrinsic[t][l] + oric2team[l];
 
-                rTeam2KnapsackM[i][l] =
-                    rRewardTeam[l] + rExtrinsicOutputDepartment[t][l] + mORIC2Team[l];
-                
                 // Remove the edge index from the unique list
-                vector<int>::iterator position =
-                    std::find(unique_edge_department.begin(), unique_edge_department.end(), l);
-                unique_edge_department.erase(position);
+                vector<int>::iterator position = std::find(unique_edges.begin(), unique_edges.end(), l);
+                unique_edges.erase(position);
             }
         }
 
         // Update team to knapsack constraint messages for remaining unique edge department indices
-        for (auto u : unique_edge_department)
-        {
-            rTeam2KnapsackM[i][u] = rRewardTeam[u] + mORIC2Team[u];
+        for (auto u : unique_edges) {
+            team2knapsack[i][u] = reward[u] + oric2team[u];
         }
     }
 }
@@ -367,53 +278,36 @@ void Knapsack::team_to_knapsack_update(const vector<vector<int>>          &rNonZ
 /**
  * Calculate messages from departments to teams based on filtering conditions for the Knapsack-MWM problem
  *
- * @param[in] department_index: index of department (knapsack constraint)
+ * @param[in] idx: index of department (knapsack constraint)
  * @param[in] iter: iteration index
- * @param[in] rExtrinsicOutputDepartmentDummy: extrinsic output messages from department to teams before filtering
- * @param[out] rExtrinsicOutputDepartment: extrinsic output messages from department to teams after filtering
- * 
+ * @param[in] extrinsic_in: extrinsic_ output messages from department to teams before filtering
+ * @param[out] extrinsic_out: extrinsic_ output messages from department to teams after filtering
+ *
  */
 
-void Knapsack::process_extrinsic_output_department(const int department_index, const int iter,
-                                                   const vector<impalib_type> &rExtrinsicOutput,
-                                                   vector<impalib_type> &rExtrinsicOutputDepartment)
-{
-
-    if ((filteringFlag_) and (alpha_ != zero_value))
-    {
-        auto intermediate_dummy = rExtrinsicOutput;
-        auto intermediate_old = extrinsicOutputDepartmentOld_[department_index];
-        vector<impalib_type> intermediate_extrinsic;
+void Knapsack::process_extrinsic_output_department(const int idx, const int iter, const vector<impalib_type> &extrinsic_in, vector<impalib_type> &extrinsic_out) {
+    if ((filteringFlag_) and (alpha_ != zero_value)) {
+        auto temp = extrinsic_in;
+        auto temp_old = extrinsic_old[idx];
+        vector<impalib_type> temp_extrinsic;
 
         impalib_type w_1 = alpha_, w_2 = 1 - alpha_;
 
-        // Calculate weighted extrinsic outputs
-        transform(intermediate_dummy.begin(), intermediate_dummy.end(), intermediate_dummy.begin(),
-                  [w_2](impalib_type &c) { return c * w_2; });
-        transform(intermediate_old.begin(), intermediate_old.end(), intermediate_old.begin(),
-                  [w_1](impalib_type &c) { return c * w_1; });
+        // Calculate weighted extrinsic_ outputs
+        transform(temp.begin(), temp.end(), temp.begin(), [w_2](impalib_type &c) { return c * w_2; });
+        transform(temp_old.begin(), temp_old.end(), temp_old.begin(), [w_1](impalib_type &c) { return c * w_1; });
 
-        if (iter == 0)
-        {
-            copy(intermediate_dummy.begin(), intermediate_dummy.end(),
-                 rExtrinsicOutputDepartment.begin());
+        if (iter == 0) {
+            copy(temp.begin(), temp.end(), extrinsic_out.begin());
+        } else {
+            transform(temp.begin(), temp.end(), temp_old.begin(), std::back_inserter(temp_extrinsic), std::plus<impalib_type>());
+            copy(temp_extrinsic.begin(), temp_extrinsic.end(), extrinsic_out.begin());
         }
-        else
-        {
-            transform(intermediate_dummy.begin(), intermediate_dummy.end(), intermediate_old.begin(),
-                      std::back_inserter(intermediate_extrinsic), std::plus<impalib_type>());
-            copy(intermediate_extrinsic.begin(), intermediate_extrinsic.end(),
-                 rExtrinsicOutputDepartment.begin());
-        }
-        
-        copy(rExtrinsicOutputDepartment.begin(), rExtrinsicOutputDepartment.end(),
-             extrinsicOutputDepartmentOld_[department_index].begin());
+
+        copy(extrinsic_out.begin(), extrinsic_out.end(), extrinsic_old[idx].begin());
     }
 
-    else
-    {
-        copy(rExtrinsicOutput.begin(),
-             rExtrinsicOutput.end(),
-             rExtrinsicOutputDepartment.begin());
+    else {
+        copy(extrinsic_in.begin(), extrinsic_in.end(), extrinsic_out.begin());
     }
 }

--- a/include/impalib/knapsack.hpp
+++ b/include/impalib/knapsack.hpp
@@ -43,14 +43,9 @@ class Knapsack {
  * @param[in] N_TEAMS: number of teams
  * @param[in] FILT_FLAG: filtering flag
  * @param[in] ALPHA: filtering parameter (between 0 and 1)
- * @param[out] numDepartments_: N_DEPARTMENTS
- * @param[out] numTeams_: N_TEAMS
- * @param[out] filteringFlag_: FILT_FLAG
- * @param[out] alpha_: ALPHA
  *
  */
-
-Knapsack::Knapsack(const int N_DEPARTMENTS, const int N_TEAMS, const bool FILT_FLAG, const impalib_type ALPHA)
+inline Knapsack::Knapsack(const int N_DEPARTMENTS, const int N_TEAMS, const bool FILT_FLAG, const impalib_type ALPHA)
     : numDepartments_(N_DEPARTMENTS), numTeams_(N_TEAMS), filteringFlag_(FILT_FLAG), alpha_(ALPHA), extrinsic_old(numDepartments_, vector<impalib_type>(numTeams_, 0)){};
 
 /**
@@ -60,13 +55,12 @@ Knapsack::Knapsack(const int N_DEPARTMENTS, const int N_TEAMS, const bool FILT_F
  * @param[in] capacity: capacity of department under
  * @param[in] idx_nonzero: indices where connections are present between teams and departments
  * @param[in] idx_nonzero_sizes: sizes of non-zero weight indices
- * @param[in] rTeamsWeightsPerDepartment: weights of teams for the department under investigation
+ * @param[in] weights: weights of teams for the department under investigation
  * @param[in] team2knapsack: messages from teams to knapsack constraints
- * @param[out] rStageForwardMessages: calculated forward messages on the trellis
+ * @returns: calculated forward messages on the trellis
  *
  */
-
-vector<vector<impalib_type>> Knapsack::forward(const int idx, const int capacity, const vector<int> &idx_nonzero, const int *idx_nonzero_sizes, const vector<int> &weights,
+inline vector<vector<impalib_type>> Knapsack::forward(const int idx, const int capacity, const vector<int> &idx_nonzero, const int *idx_nonzero_sizes, const vector<int> &weights,
                                                const vector<vector<impalib_type>> &team2knapsack) {
     vector<int>::const_iterator upper;
     vector<vector<impalib_type>> forward(numTeams_ + 1, vector<impalib_type>(capacity + 1, zero_value));
@@ -128,11 +122,10 @@ vector<vector<impalib_type>> Knapsack::forward(const int idx, const int capacity
  * @param[in] idx_nonzero_sizes: sizes of non-zero weight indices
  * @param[in] weights: weights of teams for the department under investigation
  * @param[in] team2knapsack: messages from teams to knapsack constraints
- * @param[out] rStageBackwardMessages: calculated backward messages on the trellis
+ * @returns: calculated backward messages on the trellis
  *
  */
-
-vector<vector<impalib_type>> Knapsack::backward(const int idx, const int capacity, const vector<int> &idx_nonzero, const int *idx_nonzero_sizes, const vector<int> &weights,
+inline vector<vector<impalib_type>> Knapsack::backward(const int idx, const int capacity, const vector<int> &idx_nonzero, const int *idx_nonzero_sizes, const vector<int> &weights,
                                                 const vector<vector<impalib_type>> &team2knapsack) {
     vector<int>::const_iterator upper;
     vector<vector<impalib_type>> backward(numTeams_ + 1, vector<impalib_type>(capacity + 1, zero_value));
@@ -193,11 +186,10 @@ vector<vector<impalib_type>> Knapsack::backward(const int idx, const int capacit
  * @param[in] idx: index of department (knapsack constraint)
  * @param[in] backward: calculated backward messages on the trellis
  * @param[in] capacity: capacity of department under
- * @param[out] rExtrinsicOutputDepartment: extrinsic_ output messages from department to teams
+ * @returns: extrinsic_ output messages from department to teams
  *
  */
-
-vector<impalib_type> Knapsack::extrinsic_output_department_lhs(const vector<int> &weights, const vector<vector<impalib_type>> &forward, const vector<vector<impalib_type>> &team2knapsack,
+inline vector<impalib_type> Knapsack::extrinsic_output_department_lhs(const vector<int> &weights, const vector<vector<impalib_type>> &forward, const vector<vector<impalib_type>> &team2knapsack,
                                                                const int idx, const vector<vector<impalib_type>> &backward, const int capacity) {
     vector<impalib_type> extrinsic(weights.size());
     vector<impalib_type> solid, dash;
@@ -239,8 +231,7 @@ vector<impalib_type> Knapsack::extrinsic_output_department_lhs(const vector<int>
  * @param[out] oric2team: messages from ORIC to teams
  *
  */
-
-void Knapsack::team_to_knapsack_update(const vector<vector<int>> &idx_nonzero, vector<vector<impalib_type>> &team2knapsack, const vector<impalib_type> &reward,
+inline void Knapsack::team_to_knapsack_update(const vector<vector<int>> &idx_nonzero, vector<vector<impalib_type>> &team2knapsack, const vector<impalib_type> &reward,
                                        const vector<vector<impalib_type>> &extrinsic, const vector<impalib_type> &oric2team) {
     for (int i = 0; i < extrinsic.size(); i++) {
         // Create a list of remaining departments
@@ -281,11 +272,10 @@ void Knapsack::team_to_knapsack_update(const vector<vector<int>> &idx_nonzero, v
  * @param[in] idx: index of department (knapsack constraint)
  * @param[in] iter: iteration index
  * @param[in] extrinsic_in: extrinsic_ output messages from department to teams before filtering
- * @param[out] extrinsic_out: extrinsic_ output messages from department to teams after filtering
+ * @returns: extrinsic_ output messages from department to teams after filtering
  *
  */
-
-vector<impalib_type> Knapsack::process_extrinsic_output_department(const int idx, const int iter, const vector<impalib_type> &extrinsic_in) {
+inline vector<impalib_type> Knapsack::process_extrinsic_output_department(const int idx, const int iter, const vector<impalib_type> &extrinsic_in) {
     if (!filteringFlag_) {
         return extrinsic_in;
     }

--- a/include/impalib/knapsack.hpp
+++ b/include/impalib/knapsack.hpp
@@ -21,16 +21,16 @@ class Knapsack {
 
    public:
     vector<vector<impalib_type>> forward(int, int, const vector<int> &, const int *, const vector<int> &,
-                                         const vector<vector<impalib_type>> &);  ///< forward pass of forward-backward algorithm
+                                         const vector<vector<impalib_type>> &) const;  ///< forward pass of forward-backward algorithm
 
     vector<vector<impalib_type>> backward(int, int, const vector<int> &, const int *, const vector<int> &,
-                                          const vector<vector<impalib_type>> &);  ///< backward pass of forward-backward algorithm
+                                          const vector<vector<impalib_type>> &) const;  ///< backward pass of forward-backward algorithm
 
-    vector<impalib_type> extrinsic_output_department_lhs(const vector<int> &, const vector<vector<impalib_type>> &, const vector<vector<impalib_type>> &, int, const vector<vector<impalib_type>> &,
+    static vector<impalib_type> extrinsic_output_department_lhs(const vector<int> &, const vector<vector<impalib_type>> &, const vector<vector<impalib_type>> &, int, const vector<vector<impalib_type>> &,
                                                          int);  ///< extrinsic_ output of department constraint
 
     void team_to_knapsack_update(const vector<vector<int>> &, vector<vector<impalib_type>> &, const vector<impalib_type> &, const vector<vector<impalib_type>> &,
-                                 const vector<impalib_type> &);                                        ///< calculate messages from teams to knapsack constraints
+                                 const vector<impalib_type> &) const;                                        ///< calculate messages from teams to knapsack constraints
     vector<impalib_type> process_extrinsic_output_department(int, int, const vector<impalib_type> &);  ///< perform filtering (if needed) on messages from departments to teams
 
     Knapsack(int N_DEPARTMENTS, int N_TEAMS, bool FILT_FLAG, impalib_type ALPHA);  ///< constructor
@@ -61,7 +61,7 @@ inline Knapsack::Knapsack(const int N_DEPARTMENTS, const int N_TEAMS, const bool
  *
  */
 inline vector<vector<impalib_type>> Knapsack::forward(const int idx, const int capacity, const vector<int> &idx_nonzero, const int *idx_nonzero_sizes, const vector<int> &weights,
-                                               const vector<vector<impalib_type>> &team2knapsack) {
+                                               const vector<vector<impalib_type>> &team2knapsack) const {
     vector<int>::const_iterator upper;
     vector<vector<impalib_type>> forward(numTeams_ + 1, vector<impalib_type>(capacity + 1, zero_value));
 
@@ -126,7 +126,7 @@ inline vector<vector<impalib_type>> Knapsack::forward(const int idx, const int c
  *
  */
 inline vector<vector<impalib_type>> Knapsack::backward(const int idx, const int capacity, const vector<int> &idx_nonzero, const int *idx_nonzero_sizes, const vector<int> &weights,
-                                                const vector<vector<impalib_type>> &team2knapsack) {
+                                                const vector<vector<impalib_type>> &team2knapsack) const {
     vector<int>::const_iterator upper;
     vector<vector<impalib_type>> backward(numTeams_ + 1, vector<impalib_type>(capacity + 1, zero_value));
 
@@ -232,7 +232,7 @@ inline vector<impalib_type> Knapsack::extrinsic_output_department_lhs(const vect
  *
  */
 inline void Knapsack::team_to_knapsack_update(const vector<vector<int>> &idx_nonzero, vector<vector<impalib_type>> &team2knapsack, const vector<impalib_type> &reward,
-                                       const vector<vector<impalib_type>> &extrinsic, const vector<impalib_type> &oric2team) {
+                                       const vector<vector<impalib_type>> &extrinsic, const vector<impalib_type> &oric2team) const {
     for (int i = 0; i < extrinsic.size(); i++) {
         // Create a list of remaining departments
         vector<int> remaining(numDepartments_);

--- a/include/impalib/knapsack.hpp
+++ b/include/impalib/knapsack.hpp
@@ -21,20 +21,20 @@ private:
     vector<vector<impalib_type>> extrinsicOutputDepartmentOld_; ///< messages from departments to teams equality constraint before filtering
 
 public:
-    void forward(int, vector<vector<impalib_type>> &, int, vector<int> &, const int *, vector<int> &,
-                 vector<vector<impalib_type>> &); ///< forward pass of forward-backward algorithm
+    void forward(int, vector<vector<impalib_type>> &, int, const vector<int> &, const int *, const vector<int> &,
+                 const vector<vector<impalib_type>> &); ///< forward pass of forward-backward algorithm
 
-    void backward(int, vector<vector<impalib_type>> &, int, vector<int> &, const int *, vector<int> &,
-                  vector<vector<impalib_type>> &); ///< backward pass of forward-backward algorithm
+    void backward(int, vector<vector<impalib_type>> &, int, const vector<int> &, const int *, const vector<int> &,
+                  const vector<vector<impalib_type>> &); ///< backward pass of forward-backward algorithm
 
-    vector<impalib_type> extrinsic_output_department_lhs(vector<int> &, vector<vector<impalib_type>> &,
-                                         vector<vector<impalib_type>> &, int, vector<vector<impalib_type>> &, int); ///< extrinsic output of department constraint
+    vector<impalib_type> extrinsic_output_department_lhs(const vector<int> &, const vector<vector<impalib_type>> &,
+                                         const vector<vector<impalib_type>> &, int, const vector<vector<impalib_type>> &, int); ///< extrinsic output of department constraint
 
-    void team_to_knapsack_update(vector<vector<int>> &, vector<vector<impalib_type>> &, vector<impalib_type> &,
-                                 vector<vector<impalib_type>> &, vector<impalib_type> &); ///< calculate messages from teams to knapsack constraints
-    void process_extrinsic_output_department(int, int, vector<impalib_type> &, vector<vector<impalib_type>> &); ///< perform filtering (if needed) on messages from departments to teams
+    void team_to_knapsack_update(const vector<vector<int>> &, vector<vector<impalib_type>> &, const vector<impalib_type> &,
+                                 const vector<vector<impalib_type>> &, const vector<impalib_type> &); ///< calculate messages from teams to knapsack constraints
+    void process_extrinsic_output_department(int, int, const vector<impalib_type> &, vector<vector<impalib_type>> &); ///< perform filtering (if needed) on messages from departments to teams
 
-    Knapsack(const int N_DEPARTMENTS, const int N_TEAMS, const bool FILT_FLAG, const impalib_type ALPHA); ///< constructor
+    Knapsack(int N_DEPARTMENTS, int N_TEAMS, bool FILT_FLAG, impalib_type ALPHA); ///< constructor
 };
 
 /**
@@ -70,12 +70,12 @@ Knapsack::Knapsack(const int N_DEPARTMENTS, const int N_TEAMS, const bool FILT_F
  * 
  */
 
-void Knapsack::forward(int department_index, vector<vector<impalib_type>> &rStageForwardMessages,
-                       int max_state_department, vector<int> &rNonZeroWeightIndices,
-                       const int *pNON_ZERO_WEIGHT_INDICES_SIZES_PY, vector<int> &rTeamWeights,
-                       vector<vector<impalib_type>> &rTeam2KnapsackM)
+void Knapsack::forward(const int department_index, vector<vector<impalib_type>> &rStageForwardMessages,
+                       const int max_state_department, const vector<int> &rNonZeroWeightIndices,
+                       const int *pNON_ZERO_WEIGHT_INDICES_SIZES_PY, const vector<int> &rTeamWeights,
+                       const vector<vector<impalib_type>> &rTeam2KnapsackM)
 {
-    vector<int>::iterator upper;
+    vector<int>::const_iterator upper;
 
     // Initialize initial forward messages
     vector<impalib_type> initial_forward_messages(max_state_department + 1, zero_value);
@@ -157,13 +157,13 @@ void Knapsack::forward(int department_index, vector<vector<impalib_type>> &rStag
  * 
  */
 
-void Knapsack::backward(int department_index, vector<vector<impalib_type>> &rStageBackwardMessages,
-                        int max_state_department, vector<int> &rNonZeroWeightIndices,
-                        const int *pNON_ZERO_WEIGHT_INDICES_SIZES_PY, vector<int> &rTeamsWeightsPerDepartment,
-                        vector<vector<impalib_type>> &rTeam2KnapsackM)
+void Knapsack::backward(const int department_index, vector<vector<impalib_type>> &rStageBackwardMessages,
+                        const int max_state_department, const vector<int> &rNonZeroWeightIndices,
+                        const int *pNON_ZERO_WEIGHT_INDICES_SIZES_PY, const vector<int> &rTeamsWeightsPerDepartment,
+                        const vector<vector<impalib_type>> &rTeam2KnapsackM)
 {
 
-    vector<int>::iterator upper;
+    vector<int>::const_iterator upper;
 
     // Initialize initial backward messages
     vector<impalib_type>  initial_backward_messages(max_state_department + 1, zero_value);
@@ -245,11 +245,11 @@ void Knapsack::backward(int department_index, vector<vector<impalib_type>> &rSta
  * 
  */
 
-vector<impalib_type> Knapsack::extrinsic_output_department_lhs(vector<int>          &rTeamsWeightsPerDepartment,
-                                               vector<vector<impalib_type>> &rStageForwardMessages,
-                                               vector<vector<impalib_type>> &rTeam2KnapsackM, int department_index,
-                                               vector<vector<impalib_type>> &rStageBackwardMessages,
-                                               int                           max_state_department)
+vector<impalib_type> Knapsack::extrinsic_output_department_lhs(const vector<int>          &rTeamsWeightsPerDepartment,
+                                               const vector<vector<impalib_type>> &rStageForwardMessages,
+                                               const vector<vector<impalib_type>> &rTeam2KnapsackM, const int department_index,
+                                               const vector<vector<impalib_type>> &rStageBackwardMessages,
+                                               const int                           max_state_department)
 {
     vector<impalib_type> rExtrinsicOutput(rTeamsWeightsPerDepartment.size());
     vector<impalib_type> metric_path_solid, metric_path_dash;
@@ -313,10 +313,10 @@ vector<impalib_type> Knapsack::extrinsic_output_department_lhs(vector<int>      
  * 
  */
 
-void Knapsack::team_to_knapsack_update(vector<vector<int>>          &rNonZeroWeightIndices,
-                                       vector<vector<impalib_type>> &rTeam2KnapsackM, vector<impalib_type> &rRewardTeam,
-                                       vector<vector<impalib_type>> &rExtrinsicOutputDepartment,
-                                       vector<impalib_type>         &mORIC2Team)
+void Knapsack::team_to_knapsack_update(const vector<vector<int>>          &rNonZeroWeightIndices,
+                                       vector<vector<impalib_type>> &rTeam2KnapsackM, const vector<impalib_type> &rRewardTeam,
+                                       const vector<vector<impalib_type>> &rExtrinsicOutputDepartment,
+                                       const vector<impalib_type>         &mORIC2Team)
 {
     for (int i = 0; i < rExtrinsicOutputDepartment.size(); i++)
     {
@@ -370,8 +370,8 @@ void Knapsack::team_to_knapsack_update(vector<vector<int>>          &rNonZeroWei
  * 
  */
 
-void Knapsack::process_extrinsic_output_department(int department_index, int iter,
-                                                   vector<impalib_type> &rExtrinsicOutput,
+void Knapsack::process_extrinsic_output_department(const int department_index, const int iter,
+                                                   const vector<impalib_type> &rExtrinsicOutput,
                                                    vector<vector<impalib_type>> &rExtrinsicOutputDepartment)
 {
 

--- a/include/impalib/knapsack.hpp
+++ b/include/impalib/knapsack.hpp
@@ -30,8 +30,8 @@ class Knapsack {
                                                          int);  ///< extrinsic_ output of department constraint
 
     void team_to_knapsack_update(const vector<vector<int>> &, vector<vector<impalib_type>> &, const vector<impalib_type> &, const vector<vector<impalib_type>> &,
-                                 const vector<impalib_type> &);                                                ///< calculate messages from teams to knapsack constraints
-    void process_extrinsic_output_department(int, int, const vector<impalib_type> &, vector<impalib_type> &);  ///< perform filtering (if needed) on messages from departments to teams
+                                 const vector<impalib_type> &);                                        ///< calculate messages from teams to knapsack constraints
+    vector<impalib_type> process_extrinsic_output_department(int, int, const vector<impalib_type> &);  ///< perform filtering (if needed) on messages from departments to teams
 
     Knapsack(int N_DEPARTMENTS, int N_TEAMS, bool FILT_FLAG, impalib_type ALPHA);  ///< constructor
 };
@@ -285,29 +285,17 @@ void Knapsack::team_to_knapsack_update(const vector<vector<int>> &idx_nonzero, v
  *
  */
 
-void Knapsack::process_extrinsic_output_department(const int idx, const int iter, const vector<impalib_type> &extrinsic_in, vector<impalib_type> &extrinsic_out) {
-    if ((filteringFlag_) and (alpha_ != zero_value)) {
-        auto temp = extrinsic_in;
-        auto temp_old = extrinsic_old[idx];
-        vector<impalib_type> temp_extrinsic;
-
-        impalib_type w_1 = alpha_, w_2 = 1 - alpha_;
-
-        // Calculate weighted extrinsic_ outputs
-        transform(temp.begin(), temp.end(), temp.begin(), [w_2](impalib_type &c) { return c * w_2; });
-        transform(temp_old.begin(), temp_old.end(), temp_old.begin(), [w_1](impalib_type &c) { return c * w_1; });
-
-        if (iter == 0) {
-            copy(temp.begin(), temp.end(), extrinsic_out.begin());
-        } else {
-            transform(temp.begin(), temp.end(), temp_old.begin(), std::back_inserter(temp_extrinsic), std::plus<impalib_type>());
-            copy(temp_extrinsic.begin(), temp_extrinsic.end(), extrinsic_out.begin());
-        }
-
-        copy(extrinsic_out.begin(), extrinsic_out.end(), extrinsic_old[idx].begin());
+vector<impalib_type> Knapsack::process_extrinsic_output_department(const int idx, const int iter, const vector<impalib_type> &extrinsic_in) {
+    if (!filteringFlag_) {
+        return extrinsic_in;
     }
 
-    else {
-        copy(extrinsic_in.begin(), extrinsic_in.end(), extrinsic_out.begin());
+    // Calculate weighted extrinsic outputs
+    auto extrinsic_out = extrinsic_in;
+    for (int j = 0; j < extrinsic_out.size(); ++j) {
+        extrinsic_out[j] = (1 - alpha_) * extrinsic_out[j] + (alpha_)*extrinsic_old[idx][j];
     }
+
+    extrinsic_old[idx] = extrinsic_out;
+    return extrinsic_out;
 }

--- a/include/impalib/knapsack.hpp
+++ b/include/impalib/knapsack.hpp
@@ -56,10 +56,8 @@ Knapsack::Knapsack(const int N_DEPARTMENTS, const int N_TEAMS, const bool FILT_F
     : numDepartments_(N_DEPARTMENTS), numTeams_(N_TEAMS), filteringFlag_(FILT_FLAG), alpha_(ALPHA)
 {
 
-    // Reserve memory for extrinsic output department
-    extrinsicOutputDepartmentOld_.reserve(numDepartments_);
-
     // Initialize extrinsic output department
+    extrinsicOutputDepartmentOld_.reserve(numDepartments_);
     for (int department_index = 0; department_index < numDepartments_; department_index++)
     {
         extrinsicOutputDepartmentOld_.push_back(vector<impalib_type>(numTeams_, zero_value));
@@ -84,7 +82,6 @@ void Knapsack::forward(int department_index, vector<vector<impalib_type>> &rStag
                        const int *pNON_ZERO_WEIGHT_INDICES_SIZES_PY, vector<vector<int>> &rTeamsWeightsPerDepartment,
                        vector<vector<impalib_type>> &rTeam2KnapsackM)
 {
-    // Initialize iterator
     vector<int>::iterator upper;
 
     // Initialize initial forward messages
@@ -103,11 +100,9 @@ void Knapsack::forward(int department_index, vector<vector<impalib_type>> &rStag
         }
     }
 
-    // Iterate over non-zero weight indices
     for (int l = 0; l < pNON_ZERO_WEIGHT_INDICES_SIZES_PY[department_index]; l++)
     {
         int t = rNonZeroWeightIndices[department_index][l];
-        // Iterate over states
         for (int a = 0; a <= max_state_department; a++)
         {
             if (a - rTeamsWeightsPerDepartment[department_index][t] >= 0
@@ -175,7 +170,6 @@ void Knapsack::backward(int department_index, vector<vector<impalib_type>> &rSta
                         vector<vector<impalib_type>> &rTeam2KnapsackM)
 {
 
-    // Initialize iterator
     vector<int>::iterator upper;
 
     // Initialize initial backward messages
@@ -194,12 +188,9 @@ void Knapsack::backward(int department_index, vector<vector<impalib_type>> &rSta
         }
     }
 
-    // Iterate over non-zero weight indices in reverse order
     for (int l = pNON_ZERO_WEIGHT_INDICES_SIZES_PY[department_index] - 1; l >= 0; l--)
     {
         int t = rNonZeroWeightIndices[department_index][l];
-
-        // Iterate over states
         for (int a = 0; a <= max_state_department; a++)
         {
             if ((t > 0 && a + rTeamsWeightsPerDepartment[department_index][t] <= max_state_department)
@@ -272,7 +263,6 @@ void Knapsack::extrinsic_output_department_lhs(vector<vector<int>>          &rTe
     // Initialize metric paths
     vector<impalib_type> metric_path_solid, metric_path_dash;
 
-    // Iterate over teams in the department
     for (int team_index = 0; team_index < rTeamsWeightsPerDepartment[department_index].size(); team_index++)
     {
         metric_path_dash.clear();
@@ -336,7 +326,6 @@ void Knapsack::team_to_knapsack_update(vector<vector<int>>          &rNonZeroWei
                                        vector<vector<impalib_type>> &rExtrinsicOutputDepartment,
                                        vector<impalib_type>         &mORIC2Team)
 {
-    // Iterate over departments
     for (int department_index = 0; department_index < rExtrinsicOutputDepartment.size(); department_index++)
     {
         // Create a list of remaining departments
@@ -347,7 +336,6 @@ void Knapsack::team_to_knapsack_update(vector<vector<int>>          &rNonZeroWei
         vector<int> unique_edge_department(rNonZeroWeightIndices[department_index]);
         remaining_departments.erase(remaining_departments.begin() + department_index);
 
-        // Iterate over remaining departments
         for (auto t : remaining_departments)
         {
             // Calculate intersection of non-zero weight indices between the current department and other departments
@@ -395,14 +383,12 @@ void Knapsack::process_extrinsic_output_department(int department_index, int ite
                                                    vector<vector<impalib_type>> &rExtrinsicOutputDepartment)
 {
 
-    // Check if filtering and alpha value are enabled
     if ((filteringFlag_) and (alpha_ != zero_value))
     {
 
         vector<impalib_type> intermediate_dummy(rExtrinsicOutputDepartmentDummy[department_index]),
             intermediate_old(extrinsicOutputDepartmentOld_[department_index]), intermediate_extrinsic;
-        
-        // Define weights
+
         impalib_type w_1 = alpha_, w_2 = 1 - alpha_;
 
         // Calculate weighted extrinsic outputs
@@ -411,7 +397,6 @@ void Knapsack::process_extrinsic_output_department(int department_index, int ite
         transform(intermediate_old.begin(), intermediate_old.end(), intermediate_old.begin(),
                   [w_1](impalib_type &c) { return c * w_1; });
 
-        // Update extrinsic output department based on the iteration
         if (iter == 0)
         {
             copy(intermediate_dummy.begin(), intermediate_dummy.end(),
@@ -419,7 +404,6 @@ void Knapsack::process_extrinsic_output_department(int department_index, int ite
         }
         else
         {
-            // Update extrinsic output department for the next iteration
             transform(intermediate_dummy.begin(), intermediate_dummy.end(), intermediate_old.begin(),
                       std::back_inserter(intermediate_extrinsic), std::plus<impalib_type>());
             copy(intermediate_extrinsic.begin(), intermediate_extrinsic.end(),
@@ -432,7 +416,6 @@ void Knapsack::process_extrinsic_output_department(int department_index, int ite
 
     else
     {
-        // Copy extrinsic output department directly
         copy(rExtrinsicOutputDepartmentDummy[department_index].begin(),
              rExtrinsicOutputDepartmentDummy[department_index].end(),
              rExtrinsicOutputDepartment[department_index].begin());

--- a/include/impalib/project_inequality_constraint.hpp
+++ b/include/impalib/project_inequality_constraint.hpp
@@ -20,8 +20,8 @@ private:
     int maxStateIc_ = 1; ///< maximum value of project inequality constraint (<=1)
 
 public:
-    void project_inequality_constraint_update(vector<vector<impalib_type>> &, vector<vector<impalib_type>> &); ///< calculate messages from project inequality constraint to project equality constraint
-    InequalityConstraint(const int N_DEPARTMENTS, const int N_TEAMS, const int N_PROJECTS); ///< constructor
+    void project_inequality_constraint_update(const vector<vector<impalib_type>> &, vector<vector<impalib_type>> &); ///< calculate messages from project inequality constraint to project equality constraint
+    InequalityConstraint(int N_DEPARTMENTS, int N_TEAMS, int N_PROJECTS); ///< constructor
 };
 
 /**
@@ -45,7 +45,7 @@ InequalityConstraint::InequalityConstraint(const int N_DEPARTMENTS, const int N_
  * 
  */
 
-void InequalityConstraint::project_inequality_constraint_update(vector<vector<impalib_type>> &rEqConstraint2ProjectM,
+void InequalityConstraint::project_inequality_constraint_update(const vector<vector<impalib_type>> &rEqConstraint2ProjectM,
                                                                 vector<vector<impalib_type>> &rProject2EqConstraintM)
 {
 

--- a/include/impalib/project_inequality_constraint.hpp
+++ b/include/impalib/project_inequality_constraint.hpp
@@ -54,7 +54,7 @@ void InequalityConstraint::project_inequality_constraint_update(vector<vector<im
     vector<vector<impalib_type>> stage_backward_messages_project_EC(numTeams_ + 1,
                                                                     vector<impalib_type>(maxStateIc_ + 1, zero_value));
 
-    for (int project_index = 0; project_index < rProject2EqConstraintM.size(); project_index++)
+    for (int i = 0; i < rProject2EqConstraintM.size(); i++)
     {
         // Initialize forward messages
         vector<impalib_type> initial_forward_messages(maxStateIc_ + 1, zero_value),
@@ -63,31 +63,31 @@ void InequalityConstraint::project_inequality_constraint_update(vector<vector<im
 
         stage_forward_messages_project_EC[0] = initial_forward_messages;
         
-        for (int stage = 0; stage < numTeams_; stage++)
+        for (int s = 0; s < numTeams_; s++)
         {
-            stage_forward_messages_project_EC[stage + 1][0] = stage_forward_messages_project_EC[stage][0];
-            stage_forward_messages_project_EC[stage + 1][1] =
-                min(stage_forward_messages_project_EC[stage][1],
-                    stage_forward_messages_project_EC[stage][0] + rEqConstraint2ProjectM[project_index][stage]);
+            stage_forward_messages_project_EC[s + 1][0] = stage_forward_messages_project_EC[s][0];
+            stage_forward_messages_project_EC[s + 1][1] =
+                min(stage_forward_messages_project_EC[s][1],
+                    stage_forward_messages_project_EC[s][0] + rEqConstraint2ProjectM[i][s]);
         }
 
         stage_backward_messages_project_EC[numTeams_] = initial_backward_messages;
 
-        for (int stage = numTeams_ - 1; stage >= 0; stage--)
+        for (int s = numTeams_ - 1; s >= 0; s--)
         {
-            stage_backward_messages_project_EC[stage][0] =
-                min(stage_backward_messages_project_EC[stage + 1][0],
-                    stage_backward_messages_project_EC[stage + 1][1] + rEqConstraint2ProjectM[project_index][stage]);
-            stage_backward_messages_project_EC[stage][1] = stage_backward_messages_project_EC[stage + 1][1];
+            stage_backward_messages_project_EC[s][0] =
+                min(stage_backward_messages_project_EC[s + 1][0],
+                    stage_backward_messages_project_EC[s + 1][1] + rEqConstraint2ProjectM[i][s]);
+            stage_backward_messages_project_EC[s][1] = stage_backward_messages_project_EC[s + 1][1];
         }
 
         // Update project to equality constraint messages
-        for (int team_index = 0; team_index < numTeams_; team_index++)
+        for (int j = 0; j < numTeams_; j++)
         {
             impalib_type minimumValue                         = zero_value;
-            minimumValue                                      = min(stage_forward_messages_project_EC[team_index][1],
-                                                                    stage_backward_messages_project_EC[team_index + 1][0]);
-            rProject2EqConstraintM[project_index][team_index] = -min(minimumValue, zero_value);
+            minimumValue                                      = min(stage_forward_messages_project_EC[j][1],
+                                                                    stage_backward_messages_project_EC[j + 1][0]);
+            rProject2EqConstraintM[i][j] = -min(minimumValue, zero_value);
         }
     }
 }

--- a/include/impalib/project_inequality_constraint.hpp
+++ b/include/impalib/project_inequality_constraint.hpp
@@ -11,17 +11,16 @@
 /**
  * Represents a class for the inequality constraint for the Knapsack-MWM problem
  */
-class InequalityConstraint
-{
-private:
-    int numProjects_; ///< number of projects
-    int numTeams_; ///< number of teams
-    int numDepartments_; ///< number of departments
-    int maxStateIc_ = 1; ///< maximum value of project inequality constraint (<=1)
+class InequalityConstraint {
+   private:
+    int numProjects_;     ///< number of projects
+    int numTeams_;        ///< number of teams
+    int numDepartments_;  ///< number of departments
+    int maxStateIc_ = 1;  ///< maximum value of project inequality constraint (<=1)
 
-public:
-    void project_inequality_constraint_update(const vector<vector<impalib_type>> &, vector<vector<impalib_type>> &); ///< calculate messages from project inequality constraint to project equality constraint
-    InequalityConstraint(int N_DEPARTMENTS, int N_TEAMS, int N_PROJECTS); ///< constructor
+   public:
+    vector<vector<impalib_type>> messages_to_equality(const vector<vector<impalib_type>> &eq2proj);  ///< calculate messages from project inequality constraint to project equality constraint
+    InequalityConstraint(int N_DEPARTMENTS, int N_TEAMS, int N_PROJECTS);                            ///< constructor
 };
 
 /**
@@ -30,64 +29,49 @@ public:
  * @param[out] numProjects_: N_PROJECTS
  * @param[out] numTeams_: N_TEAMS
  * @param[out] numDepartments_: N_DEPARTMENTS
- * 
+ *
  */
 
-InequalityConstraint::InequalityConstraint(const int N_DEPARTMENTS, const int N_TEAMS, const int N_PROJECTS)
-    : numProjects_(N_PROJECTS), numTeams_(N_TEAMS), numDepartments_(N_DEPARTMENTS){
-                                                    };
+InequalityConstraint::InequalityConstraint(const int N_DEPARTMENTS, const int N_TEAMS, const int N_PROJECTS) : numProjects_(N_PROJECTS), numTeams_(N_TEAMS), numDepartments_(N_DEPARTMENTS){};
 
 /**
  * Calculate messages from project inequality constraint to project equality constraint for the Knapsack-MWM problem
  *
- * @param[in] rEqConstraint2ProjectM: messages from project equality constraint to project inequality constraint
+ * @param[in] eq2proj: messages from project equality constraint to project inequality constraint
  * @param[out] rProject2EqConstraintM: messages from project inequality constraint to project equality constraint
- * 
+ *
  */
 
-void InequalityConstraint::project_inequality_constraint_update(const vector<vector<impalib_type>> &rEqConstraint2ProjectM,
-                                                                vector<vector<impalib_type>> &rProject2EqConstraintM)
-{
+vector<vector<impalib_type>> InequalityConstraint::messages_to_equality(const vector<vector<impalib_type>> &eq2proj) {
+    vector<vector<impalib_type>> proj2eq(numProjects_, vector<impalib_type>(numTeams_, 0));
+    vector<vector<impalib_type>> forward(numTeams_ + 1, vector<impalib_type>(maxStateIc_ + 1, zero_value));
+    vector<vector<impalib_type>> backward(numTeams_ + 1, vector<impalib_type>(maxStateIc_ + 1, zero_value));
 
-    vector<vector<impalib_type>> stage_forward_messages_project_EC(numTeams_ + 1,
-                                                                   vector<impalib_type>(maxStateIc_ + 1, zero_value));
-    vector<vector<impalib_type>> stage_backward_messages_project_EC(numTeams_ + 1,
-                                                                    vector<impalib_type>(maxStateIc_ + 1, zero_value));
-
-    for (int i = 0; i < rProject2EqConstraintM.size(); i++)
-    {
+    for (int i = 0; i < proj2eq.size(); i++) {
         // Initialize forward messages
-        vector<impalib_type> initial_forward_messages(maxStateIc_ + 1, zero_value),
-            initial_backward_messages(maxStateIc_ + 1, zero_value);
-        fill(initial_forward_messages.begin() + 1, initial_forward_messages.end(), value_inf);
+        vector<impalib_type> forward0(maxStateIc_ + 1, zero_value), backward0(maxStateIc_ + 1, zero_value);
+        fill(forward0.begin() + 1, forward0.end(), value_inf);
 
-        stage_forward_messages_project_EC[0] = initial_forward_messages;
-        
-        for (int s = 0; s < numTeams_; s++)
-        {
-            stage_forward_messages_project_EC[s + 1][0] = stage_forward_messages_project_EC[s][0];
-            stage_forward_messages_project_EC[s + 1][1] =
-                min(stage_forward_messages_project_EC[s][1],
-                    stage_forward_messages_project_EC[s][0] + rEqConstraint2ProjectM[i][s]);
+        forward[0] = forward0;
+
+        for (int s = 0; s < numTeams_; s++) {
+            forward[s + 1][0] = forward[s][0];
+            forward[s + 1][1] = min(forward[s][1], forward[s][0] + eq2proj[i][s]);
         }
 
-        stage_backward_messages_project_EC[numTeams_] = initial_backward_messages;
+        backward[numTeams_] = backward0;
 
-        for (int s = numTeams_ - 1; s >= 0; s--)
-        {
-            stage_backward_messages_project_EC[s][0] =
-                min(stage_backward_messages_project_EC[s + 1][0],
-                    stage_backward_messages_project_EC[s + 1][1] + rEqConstraint2ProjectM[i][s]);
-            stage_backward_messages_project_EC[s][1] = stage_backward_messages_project_EC[s + 1][1];
+        for (int s = numTeams_ - 1; s >= 0; s--) {
+            backward[s][0] = min(backward[s + 1][0], backward[s + 1][1] + eq2proj[i][s]);
+            backward[s][1] = backward[s + 1][1];
         }
 
         // Update project to equality constraint messages
-        for (int j = 0; j < numTeams_; j++)
-        {
-            impalib_type minimumValue                         = zero_value;
-            minimumValue                                      = min(stage_forward_messages_project_EC[j][1],
-                                                                    stage_backward_messages_project_EC[j + 1][0]);
-            rProject2EqConstraintM[i][j] = -min(minimumValue, zero_value);
+        for (int j = 0; j < numTeams_; j++) {
+            impalib_type minimumValue = zero_value;
+            minimumValue = min(forward[j][1], backward[j + 1][0]);
+            proj2eq[i][j] = -min(minimumValue, zero_value);
         }
     }
+    return proj2eq;
 }

--- a/include/impalib/project_inequality_constraint.hpp
+++ b/include/impalib/project_inequality_constraint.hpp
@@ -19,7 +19,7 @@ class InequalityConstraint {
     int maxStateIc_ = 1;  ///< maximum value of project inequality constraint (<=1)
 
    public:
-    vector<vector<impalib_type>> messages_to_equality(const vector<vector<impalib_type>> &eq2proj);  ///< calculate messages from project inequality constraint to project equality constraint
+    vector<vector<impalib_type>> messages_to_equality(const vector<vector<impalib_type>> &eq2proj) const;  ///< calculate messages from project inequality constraint to project equality constraint
     InequalityConstraint(int N_DEPARTMENTS, int N_TEAMS, int N_PROJECTS);                            ///< constructor
 };
 
@@ -40,7 +40,7 @@ inline InequalityConstraint::InequalityConstraint(const int N_DEPARTMENTS, const
  * @returns: messages from project inequality constraint to project equality constraint
  *
  */
-inline vector<vector<impalib_type>> InequalityConstraint::messages_to_equality(const vector<vector<impalib_type>> &eq2proj) {
+inline vector<vector<impalib_type>> InequalityConstraint::messages_to_equality(const vector<vector<impalib_type>> &eq2proj) const {
     vector<vector<impalib_type>> proj2eq(numProjects_, vector<impalib_type>(numTeams_, 0));
     vector<vector<impalib_type>> forward(numTeams_ + 1, vector<impalib_type>(maxStateIc_ + 1, zero_value));
     vector<vector<impalib_type>> backward(numTeams_ + 1, vector<impalib_type>(maxStateIc_ + 1, zero_value));

--- a/include/impalib/project_inequality_constraint.hpp
+++ b/include/impalib/project_inequality_constraint.hpp
@@ -26,23 +26,21 @@ class InequalityConstraint {
 /**
  * Construct InequalityConstraint object for the Knapsack-MWM problem
  *
- * @param[out] numProjects_: N_PROJECTS
- * @param[out] numTeams_: N_TEAMS
- * @param[out] numDepartments_: N_DEPARTMENTS
+ * @param N_PROJECTS: Number of projects
+ * @param N_TEAMS: Number of teams
+ * @param N_DEPARTMENTS: Number of departments
  *
  */
-
-InequalityConstraint::InequalityConstraint(const int N_DEPARTMENTS, const int N_TEAMS, const int N_PROJECTS) : numProjects_(N_PROJECTS), numTeams_(N_TEAMS), numDepartments_(N_DEPARTMENTS){};
+inline InequalityConstraint::InequalityConstraint(const int N_DEPARTMENTS, const int N_TEAMS, const int N_PROJECTS) : numProjects_(N_PROJECTS), numTeams_(N_TEAMS), numDepartments_(N_DEPARTMENTS){};
 
 /**
  * Calculate messages from project inequality constraint to project equality constraint for the Knapsack-MWM problem
  *
  * @param[in] eq2proj: messages from project equality constraint to project inequality constraint
- * @param[out] rProject2EqConstraintM: messages from project inequality constraint to project equality constraint
+ * @returns: messages from project inequality constraint to project equality constraint
  *
  */
-
-vector<vector<impalib_type>> InequalityConstraint::messages_to_equality(const vector<vector<impalib_type>> &eq2proj) {
+inline vector<vector<impalib_type>> InequalityConstraint::messages_to_equality(const vector<vector<impalib_type>> &eq2proj) {
     vector<vector<impalib_type>> proj2eq(numProjects_, vector<impalib_type>(numTeams_, 0));
     vector<vector<impalib_type>> forward(numTeams_ + 1, vector<impalib_type>(maxStateIc_ + 1, zero_value));
     vector<vector<impalib_type>> backward(numTeams_ + 1, vector<impalib_type>(maxStateIc_ + 1, zero_value));

--- a/include/impalib/project_inequality_constraint.hpp
+++ b/include/impalib/project_inequality_constraint.hpp
@@ -49,13 +49,11 @@ void InequalityConstraint::project_inequality_constraint_update(vector<vector<im
                                                                 vector<vector<impalib_type>> &rProject2EqConstraintM)
 {
 
-    // Define containers for forward and backward messages
     vector<vector<impalib_type>> stage_forward_messages_project_EC(numTeams_ + 1,
                                                                    vector<impalib_type>(maxStateIc_ + 1, zero_value));
     vector<vector<impalib_type>> stage_backward_messages_project_EC(numTeams_ + 1,
                                                                     vector<impalib_type>(maxStateIc_ + 1, zero_value));
 
-    // Iterate over projects
     for (int project_index = 0; project_index < rProject2EqConstraintM.size(); project_index++)
     {
         // Initialize forward messages
@@ -63,7 +61,6 @@ void InequalityConstraint::project_inequality_constraint_update(vector<vector<im
             initial_backward_messages(maxStateIc_ + 1, zero_value);
         fill(initial_forward_messages.begin() + 1, initial_forward_messages.end(), value_inf);
 
-        // Calculate forward messages
         stage_forward_messages_project_EC[0] = initial_forward_messages;
         
         for (int stage = 0; stage < numTeams_; stage++)
@@ -74,7 +71,6 @@ void InequalityConstraint::project_inequality_constraint_update(vector<vector<im
                     stage_forward_messages_project_EC[stage][0] + rEqConstraint2ProjectM[project_index][stage]);
         }
 
-        // Calculate backward messages
         stage_backward_messages_project_EC[numTeams_] = initial_backward_messages;
 
         for (int stage = numTeams_ - 1; stage >= 0; stage--)

--- a/include/impalib/subtour_elimination_constraint.hpp
+++ b/include/impalib/subtour_elimination_constraint.hpp
@@ -13,7 +13,6 @@
 /**
  * Represents a class for the subtour elimination constraint for the TSP
  */
-
 class SubtourEliminationConstraint {
    private:
     int n_Nodes;             ///< number of nodes
@@ -41,14 +40,8 @@ class SubtourEliminationConstraint {
  * @param[in] NUM_EDGE_VARIABLES: number of connections between nodes
  * @param[in] FILTERING_FLAG: filtering on or off
  * @param[in] ALPHA: filtering parameter value (between 0 and 1)
- * @param[out] filteringFlag_: FILTERING_FLAG
- * @param[out] alpha_: ALPHA
- * @param[out] numNodes_: NUM_NODES
- * @param[out] numEdgeVariables_: NUM_EDGE_VARIABLES
- * @param[out] initial_forward_message_: set to infinity
- * @param[out] initial_backward_message_: set to infinity
  */
-SubtourEliminationConstraint::SubtourEliminationConstraint(const int NUM_NODES, const int NUM_EDGE_VARIABLES, const bool FILTERING_FLAG, const impalib_type ALPHA)
+inline SubtourEliminationConstraint::SubtourEliminationConstraint(const int NUM_NODES, const int NUM_EDGE_VARIABLES, const bool FILTERING_FLAG, const impalib_type ALPHA)
     : doFilter(FILTERING_FLAG), alpha_(ALPHA), n_Nodes(NUM_NODES), n_Edges(NUM_EDGE_VARIABLES), forward0(value_inf), backward0(value_inf){};
 
 /**
@@ -59,8 +52,7 @@ SubtourEliminationConstraint::SubtourEliminationConstraint(const int NUM_NODES, 
  * @param[out] subtour2edge: messages from subtour elimination constraints to edge equality constraints
  *
  */
-
-void SubtourEliminationConstraint::messages_to_edge_ec(const vector<vector<impalib_type>> &edge2subtour, const vector<vector<int>> &deltaS, vector<vector<impalib_type>> &subtour2edge) {
+inline void SubtourEliminationConstraint::messages_to_edge_ec(const vector<vector<impalib_type>> &edge2subtour, const vector<vector<int>> &deltaS, vector<vector<impalib_type>> &subtour2edge) {
     vector<impalib_type> forward(n_Edges + 1, zero_value);
     vector<impalib_type> backward(n_Edges + 1, zero_value);
 
@@ -93,12 +85,11 @@ void SubtourEliminationConstraint::messages_to_edge_ec(const vector<vector<impal
  *
  * @param[in] iter: index of iteration of IMPA
  * @param[in] subtour2edge_in: messages from subtour elimination constraints to edge equality constraints before filtering
- * @param[out] subtour2edge_out: messages from subtour elimination constraints to edge equality constraints after filtering
  * @param[in] deltaS: list of sub-list of indices. Each sub-list is asscoiated with a subtour constraint, and contains indices of edges related to this constraint
+ * @returns: messages from subtour elimination constraints to edge equality constraints after filtering
  *
  */
-
-vector<vector<impalib_type>> SubtourEliminationConstraint::process_filtering(const int iter, const vector<vector<impalib_type>> &subtour2edge_in, const vector<vector<int>> &deltaS) {
+inline vector<vector<impalib_type>> SubtourEliminationConstraint::process_filtering(const int iter, const vector<vector<impalib_type>> &subtour2edge_in, const vector<vector<int>> &deltaS) {
     assert(subtour2edge_in.size() == deltaS.size());
     if (!doFilter) {
         return subtour2edge_in;

--- a/include/impalib/subtour_elimination_constraint.hpp
+++ b/include/impalib/subtour_elimination_constraint.hpp
@@ -65,11 +65,9 @@ void SubtourEliminationConstraint::subtour_constraints_to_edge_ec_update(
     vector<vector<impalib_type>> &rEdgeEc2SubtourConstraintsM, vector<vector<int>> &rDeltaSIndicesList,
     vector<vector<impalib_type>> &rSubtourConstraints2EdgeEcM)
 {
-    // Define containers for forward and backward messages
     vector<impalib_type> stage_forward_messages(numEdgeVariables_ + 1, zero_value);
     vector<impalib_type> stage_backward_messages(numEdgeVariables_ + 1, zero_value);
 
-    // Iterate over subtour constraints
     for (size_t index_subtour_constraint = 0; index_subtour_constraint < rDeltaSIndicesList.size();
          index_subtour_constraint++)
     {
@@ -128,15 +126,12 @@ void SubtourEliminationConstraint::process_filtering(int                        
                                                      vector<vector<int>>          &rDeltaSIndicesList)
 {
 
-    // Iterate over subtour constraints
     for (int index_subtour_constraint = 0; index_subtour_constraint < rDeltaSIndicesList.size();
          index_subtour_constraint++)
     {
 
-        // Apply filtering if enabled and alpha is not zero
         if ((filteringFlag_) and (alpha_ != zero_value))
         {
-            // Calculate intermediate values based on alpha
             vector<impalib_type> intermediate_dummy(rSubtourConstraints2EdgeEcDummyM[index_subtour_constraint]),
                 intermediate_old(subtourConstraints2EdgeEcOld_[index_subtour_constraint]), intermediate_extrinsic;
 
@@ -145,8 +140,7 @@ void SubtourEliminationConstraint::process_filtering(int                        
                       [w_2](impalib_type &c) { return c * w_2; });
             transform(intermediate_old.begin(), intermediate_old.end(), intermediate_old.begin(),
                       [w_1](impalib_type &c) { return c * w_1; });
-            
-            // Update the messages based on iteration
+
             if (iter == 0)
             {
                 copy(intermediate_dummy.begin(), intermediate_dummy.end(),
@@ -160,13 +154,11 @@ void SubtourEliminationConstraint::process_filtering(int                        
                      rSubtourConstraints2EdgeEcM[index_subtour_constraint].begin());
             }
 
-            // Update the old messages for the next iteration
             copy(rSubtourConstraints2EdgeEcM[index_subtour_constraint].begin(),
                  rSubtourConstraints2EdgeEcM[index_subtour_constraint].end(),
                  subtourConstraints2EdgeEcOld_[index_subtour_constraint].begin());
         }
 
-        // If filtering is not enabled or alpha is zero, simply copy the dummy values
         else
         {
             copy(rSubtourConstraints2EdgeEcDummyM[index_subtour_constraint].begin(),

--- a/include/impalib/subtour_elimination_constraint.hpp
+++ b/include/impalib/subtour_elimination_constraint.hpp
@@ -24,12 +24,12 @@ private:
 
 public:
     vector<vector<impalib_type>> subtourConstraints2EdgeEcOld_; ///< messages from subtour constraints to edge equality constraint before filtering
-    void subtour_constraints_to_edge_ec_update(vector<vector<impalib_type>> &, vector<vector<int>> &,
+    void subtour_constraints_to_edge_ec_update(const vector<vector<impalib_type>> &, const vector<vector<int>> &,
                                                vector<vector<impalib_type>> &); ///< calculate messages from subtour to edge equality constraints
-    void process_filtering(int, vector<vector<impalib_type>> &, vector<vector<impalib_type>> &, vector<vector<int>> &); ///< perform filtering on messages from subtour to edge equality constraints
+    void process_filtering(int, const vector<vector<impalib_type>> &, vector<vector<impalib_type>> &, const vector<vector<int>> &); ///< perform filtering on messages from subtour to edge equality constraints
 
-    SubtourEliminationConstraint(const int NUM_NODES, const int NUM_EDGE_VARIABLES, const bool FILTERING_FLAG,
-                                 const impalib_type ALPHA); ///< constructor
+    SubtourEliminationConstraint(int NUM_NODES, int NUM_EDGE_VARIABLES, bool FILTERING_FLAG,
+                                 impalib_type ALPHA); ///< constructor
 };
 
 /**
@@ -62,7 +62,7 @@ SubtourEliminationConstraint::SubtourEliminationConstraint(const int NUM_NODES, 
  */
 
 void SubtourEliminationConstraint::subtour_constraints_to_edge_ec_update(
-    vector<vector<impalib_type>> &rEdgeEc2SubtourConstraintsM, vector<vector<int>> &rDeltaSIndicesList,
+    const vector<vector<impalib_type>> &rEdgeEc2SubtourConstraintsM, const vector<vector<int>> &rDeltaSIndicesList,
     vector<vector<impalib_type>> &rSubtourConstraints2EdgeEcM)
 {
     vector<impalib_type> stage_forward_messages(numEdgeVariables_ + 1, zero_value);
@@ -119,10 +119,10 @@ void SubtourEliminationConstraint::subtour_constraints_to_edge_ec_update(
  * 
  */
 
-void SubtourEliminationConstraint::process_filtering(int                           iter,
-                                                     vector<vector<impalib_type>> &rSubtourConstraints2EdgeEcDummyM,
+void SubtourEliminationConstraint::process_filtering(const int                           iter,
+                                                     const vector<vector<impalib_type>> &rSubtourConstraints2EdgeEcDummyM,
                                                      vector<vector<impalib_type>> &rSubtourConstraints2EdgeEcM,
-                                                     vector<vector<int>>          &rDeltaSIndicesList)
+                                                     const vector<vector<int>>          &rDeltaSIndicesList)
 {
 
     for (int i = 0; i < rDeltaSIndicesList.size(); i++)

--- a/include/impalib/subtour_elimination_constraint.hpp
+++ b/include/impalib/subtour_elimination_constraint.hpp
@@ -68,43 +68,42 @@ void SubtourEliminationConstraint::subtour_constraints_to_edge_ec_update(
     vector<impalib_type> stage_forward_messages(numEdgeVariables_ + 1, zero_value);
     vector<impalib_type> stage_backward_messages(numEdgeVariables_ + 1, zero_value);
 
-    for (size_t index_subtour_constraint = 0; index_subtour_constraint < rDeltaSIndicesList.size();
-         index_subtour_constraint++)
+    for (size_t i = 0; i < rDeltaSIndicesList.size(); i++)
     {
         // Initialize and calculate forward messages
-        stage_forward_messages[rDeltaSIndicesList[index_subtour_constraint][0]] = initial_forward_message_;
-        for (int stage = 1; stage < rDeltaSIndicesList[index_subtour_constraint].size(); stage++)
+        stage_forward_messages[rDeltaSIndicesList[i][0]] = initial_forward_message_;
+        for (int stage = 1; stage < rDeltaSIndicesList[i].size(); stage++)
         {
-            stage_forward_messages[rDeltaSIndicesList[index_subtour_constraint][stage]] =
-                min(stage_forward_messages[rDeltaSIndicesList[index_subtour_constraint][stage - 1]],
-                    rEdgeEc2SubtourConstraintsM[index_subtour_constraint]
-                                               [rDeltaSIndicesList[index_subtour_constraint][stage - 1]]);
+            stage_forward_messages[rDeltaSIndicesList[i][stage]] =
+                min(stage_forward_messages[rDeltaSIndicesList[i][stage - 1]],
+                    rEdgeEc2SubtourConstraintsM[i]
+                                               [rDeltaSIndicesList[i][stage - 1]]);
         }
 
         // Initialize and calculate backward messages
-        stage_backward_messages[rDeltaSIndicesList[index_subtour_constraint]
-                                                  [rDeltaSIndicesList[index_subtour_constraint].size() - 1]
+        stage_backward_messages[rDeltaSIndicesList[i]
+                                                  [rDeltaSIndicesList[i].size() - 1]
                                 + 1] = initial_backward_message_;
 
-        for (size_t stage = rDeltaSIndicesList[index_subtour_constraint].size() - 1; stage >= 1; stage--)
+        for (size_t stage = rDeltaSIndicesList[i].size() - 1; stage >= 1; stage--)
         {
-            stage_backward_messages[rDeltaSIndicesList[index_subtour_constraint][stage - 1] + 1] =
-                min(stage_backward_messages[rDeltaSIndicesList[index_subtour_constraint][stage] + 1],
-                    rEdgeEc2SubtourConstraintsM[index_subtour_constraint]
-                                               [rDeltaSIndicesList[index_subtour_constraint][stage]]);
+            stage_backward_messages[rDeltaSIndicesList[i][stage - 1] + 1] =
+                min(stage_backward_messages[rDeltaSIndicesList[i][stage] + 1],
+                    rEdgeEc2SubtourConstraintsM[i]
+                                               [rDeltaSIndicesList[i][stage]]);
         }
 
         // Update subtour constraints to edge EC messages
-        for (int index_edge_variable = 0; index_edge_variable < rDeltaSIndicesList[index_subtour_constraint].size();
+        for (int index_edge_variable = 0; index_edge_variable < rDeltaSIndicesList[i].size();
              index_edge_variable++)
         {
             impalib_type minimumValue = zero_value;
             minimumValue =
-                min(stage_forward_messages[rDeltaSIndicesList[index_subtour_constraint][index_edge_variable]],
-                    stage_backward_messages[rDeltaSIndicesList[index_subtour_constraint][index_edge_variable] + 1]);
+                min(stage_forward_messages[rDeltaSIndicesList[i][index_edge_variable]],
+                    stage_backward_messages[rDeltaSIndicesList[i][index_edge_variable] + 1]);
             minimumValue = min(-minimumValue, zero_value);
-            rSubtourConstraints2EdgeEcM[index_subtour_constraint]
-                                       [rDeltaSIndicesList[index_subtour_constraint][index_edge_variable]] =
+            rSubtourConstraints2EdgeEcM[i]
+                                       [rDeltaSIndicesList[i][index_edge_variable]] =
                                            minimumValue;
         }
     }
@@ -126,14 +125,13 @@ void SubtourEliminationConstraint::process_filtering(int                        
                                                      vector<vector<int>>          &rDeltaSIndicesList)
 {
 
-    for (int index_subtour_constraint = 0; index_subtour_constraint < rDeltaSIndicesList.size();
-         index_subtour_constraint++)
+    for (int i = 0; i < rDeltaSIndicesList.size(); i++)
     {
 
         if ((filteringFlag_) and (alpha_ != zero_value))
         {
-            vector<impalib_type> intermediate_dummy(rSubtourConstraints2EdgeEcDummyM[index_subtour_constraint]),
-                intermediate_old(subtourConstraints2EdgeEcOld_[index_subtour_constraint]), intermediate_extrinsic;
+            vector<impalib_type> intermediate_dummy(rSubtourConstraints2EdgeEcDummyM[i]),
+                intermediate_old(subtourConstraints2EdgeEcOld_[i]), intermediate_extrinsic;
 
             impalib_type w_1 = alpha_, w_2 = 1 - alpha_;
             transform(intermediate_dummy.begin(), intermediate_dummy.end(), intermediate_dummy.begin(),
@@ -144,26 +142,26 @@ void SubtourEliminationConstraint::process_filtering(int                        
             if (iter == 0)
             {
                 copy(intermediate_dummy.begin(), intermediate_dummy.end(),
-                     rSubtourConstraints2EdgeEcM[index_subtour_constraint].begin());
+                     rSubtourConstraints2EdgeEcM[i].begin());
             }
             else
             {
                 transform(intermediate_dummy.begin(), intermediate_dummy.end(), intermediate_old.begin(),
                           back_inserter(intermediate_extrinsic), plus<impalib_type>());
                 copy(intermediate_extrinsic.begin(), intermediate_extrinsic.end(),
-                     rSubtourConstraints2EdgeEcM[index_subtour_constraint].begin());
+                     rSubtourConstraints2EdgeEcM[i].begin());
             }
 
-            copy(rSubtourConstraints2EdgeEcM[index_subtour_constraint].begin(),
-                 rSubtourConstraints2EdgeEcM[index_subtour_constraint].end(),
-                 subtourConstraints2EdgeEcOld_[index_subtour_constraint].begin());
+            copy(rSubtourConstraints2EdgeEcM[i].begin(),
+                 rSubtourConstraints2EdgeEcM[i].end(),
+                 subtourConstraints2EdgeEcOld_[i].begin());
         }
 
         else
         {
-            copy(rSubtourConstraints2EdgeEcDummyM[index_subtour_constraint].begin(),
-                 rSubtourConstraints2EdgeEcDummyM[index_subtour_constraint].end(),
-                 rSubtourConstraints2EdgeEcM[index_subtour_constraint].begin());
+            copy(rSubtourConstraints2EdgeEcDummyM[i].begin(),
+                 rSubtourConstraints2EdgeEcDummyM[i].end(),
+                 rSubtourConstraints2EdgeEcM[i].begin());
         }
     }
 }

--- a/include/impalib/subtour_elimination_constraint.hpp
+++ b/include/impalib/subtour_elimination_constraint.hpp
@@ -12,24 +12,24 @@
  * Represents a class for the subtour elimination constraint for the TSP
  */
 
-class SubtourEliminationConstraint
-{
-private:
-    int          numNodes_; ///< number of nodes
-    int          numEdgeVariables_; ///< number of edges
-    bool         filteringFlag_; ///< filtering flag
-    impalib_type alpha_; ///< filtering parameter
-    impalib_type initial_forward_message_; ///< initial value of forward message using forward-backward algorithm
-    impalib_type initial_backward_message_; ///< initial value of backward message using forward-backward algorithm
+class SubtourEliminationConstraint {
+   private:
+    int n_Nodes;             ///< number of nodes
+    int n_Edges;             ///< number of edges
+    bool doFilter;           ///< filtering flag
+    impalib_type alpha_;     ///< filtering parameter
+    impalib_type forward0;   ///< initial value of forward message using forward-backward algorithm
+    impalib_type backward0;  ///< initial value of backward message using forward-backward algorithm
 
-public:
-    vector<vector<impalib_type>> subtourConstraints2EdgeEcOld_; ///< messages from subtour constraints to edge equality constraint before filtering
-    void subtour_constraints_to_edge_ec_update(const vector<vector<impalib_type>> &, const vector<vector<int>> &,
-                                               vector<vector<impalib_type>> &); ///< calculate messages from subtour to edge equality constraints
-    void process_filtering(int, const vector<vector<impalib_type>> &, vector<vector<impalib_type>> &, const vector<vector<int>> &); ///< perform filtering on messages from subtour to edge equality constraints
+   public:
+    vector<vector<impalib_type>> M_subtour2edge_old;  ///< messages from subtour constraints to edge equality constraint before filtering
+    void messages_to_edge_ec(const vector<vector<impalib_type>> &edge2subtour, const vector<vector<int>> &deltaS,
+                             vector<vector<impalib_type>> &subtour2edge);  ///< calculate messages from subtour to edge equality constraints
+    void process_filtering(int, const vector<vector<impalib_type>> &, vector<vector<impalib_type>> &,
+                           const vector<vector<int>> &);  ///< perform filtering on messages from subtour to edge equality constraints
 
     SubtourEliminationConstraint(int NUM_NODES, int NUM_EDGE_VARIABLES, bool FILTERING_FLAG,
-                                 impalib_type ALPHA); ///< constructor
+                                 impalib_type ALPHA);  ///< constructor
 };
 
 /**
@@ -46,65 +46,42 @@ public:
  * @param[out] initial_forward_message_: set to infinity
  * @param[out] initial_backward_message_: set to infinity
  */
-SubtourEliminationConstraint::SubtourEliminationConstraint(const int NUM_NODES, const int NUM_EDGE_VARIABLES,
-                                                           const bool FILTERING_FLAG, const impalib_type ALPHA)
-    : filteringFlag_(FILTERING_FLAG), alpha_(ALPHA), numNodes_(NUM_NODES), numEdgeVariables_(NUM_EDGE_VARIABLES),
-      initial_forward_message_(value_inf), initial_backward_message_(value_inf){
-                                           };
+SubtourEliminationConstraint::SubtourEliminationConstraint(const int NUM_NODES, const int NUM_EDGE_VARIABLES, const bool FILTERING_FLAG, const impalib_type ALPHA)
+    : doFilter(FILTERING_FLAG), alpha_(ALPHA), n_Nodes(NUM_NODES), n_Edges(NUM_EDGE_VARIABLES), forward0(value_inf), backward0(value_inf){};
 
 /**
  * Calculate messages from subtour elimination constraints to edge equality constraints for the TSP
  *
- * @param[in] rEdgeEc2SubtourConstraintsM: messages from edge equality constraints to subtour elimination constraints
- * @param[in] rDeltaSIndicesList: list of sub-list of indices. Each sub-list is asscoiated with a subtour constraint, and contains indices of edges related to this constraint
- * @param[out] rSubtourConstraints2EdgeEcM: messages from subtour elimination constraints to edge equality constraints
- * 
+ * @param[in] edge2subtour: messages from edge equality constraints to subtour elimination constraints
+ * @param[in] deltaS: list of sub-list of indices. Each sub-list is asscoiated with a subtour constraint, and contains indices of edges related to this constraint
+ * @param[out] subtour2edge: messages from subtour elimination constraints to edge equality constraints
+ *
  */
 
-void SubtourEliminationConstraint::subtour_constraints_to_edge_ec_update(
-    const vector<vector<impalib_type>> &rEdgeEc2SubtourConstraintsM, const vector<vector<int>> &rDeltaSIndicesList,
-    vector<vector<impalib_type>> &rSubtourConstraints2EdgeEcM)
-{
-    vector<impalib_type> stage_forward_messages(numEdgeVariables_ + 1, zero_value);
-    vector<impalib_type> stage_backward_messages(numEdgeVariables_ + 1, zero_value);
+void SubtourEliminationConstraint::messages_to_edge_ec(const vector<vector<impalib_type>> &edge2subtour, const vector<vector<int>> &deltaS, vector<vector<impalib_type>> &subtour2edge) {
+    vector<impalib_type> forward(n_Edges + 1, zero_value);
+    vector<impalib_type> backward(n_Edges + 1, zero_value);
 
-    for (size_t i = 0; i < rDeltaSIndicesList.size(); i++)
-    {
+    for (size_t i = 0; i < deltaS.size(); i++) {
         // Initialize and calculate forward messages
-        stage_forward_messages[rDeltaSIndicesList[i][0]] = initial_forward_message_;
-        for (int stage = 1; stage < rDeltaSIndicesList[i].size(); stage++)
-        {
-            stage_forward_messages[rDeltaSIndicesList[i][stage]] =
-                min(stage_forward_messages[rDeltaSIndicesList[i][stage - 1]],
-                    rEdgeEc2SubtourConstraintsM[i]
-                                               [rDeltaSIndicesList[i][stage - 1]]);
+        forward[deltaS[i][0]] = forward0;
+        for (int stage = 1; stage < deltaS[i].size(); stage++) {
+            forward[deltaS[i][stage]] = min(forward[deltaS[i][stage - 1]], edge2subtour[i][deltaS[i][stage - 1]]);
         }
 
         // Initialize and calculate backward messages
-        stage_backward_messages[rDeltaSIndicesList[i]
-                                                  [rDeltaSIndicesList[i].size() - 1]
-                                + 1] = initial_backward_message_;
+        backward[deltaS[i][deltaS[i].size() - 1] + 1] = backward0;
 
-        for (size_t stage = rDeltaSIndicesList[i].size() - 1; stage >= 1; stage--)
-        {
-            stage_backward_messages[rDeltaSIndicesList[i][stage - 1] + 1] =
-                min(stage_backward_messages[rDeltaSIndicesList[i][stage] + 1],
-                    rEdgeEc2SubtourConstraintsM[i]
-                                               [rDeltaSIndicesList[i][stage]]);
+        for (size_t stage = deltaS[i].size() - 1; stage >= 1; stage--) {
+            backward[deltaS[i][stage - 1] + 1] = min(backward[deltaS[i][stage] + 1], edge2subtour[i][deltaS[i][stage]]);
         }
 
         // Update subtour constraints to edge EC messages
-        for (int index_edge_variable = 0; index_edge_variable < rDeltaSIndicesList[i].size();
-             index_edge_variable++)
-        {
-            impalib_type minimumValue = zero_value;
-            minimumValue =
-                min(stage_forward_messages[rDeltaSIndicesList[i][index_edge_variable]],
-                    stage_backward_messages[rDeltaSIndicesList[i][index_edge_variable] + 1]);
-            minimumValue = min(-minimumValue, zero_value);
-            rSubtourConstraints2EdgeEcM[i]
-                                       [rDeltaSIndicesList[i][index_edge_variable]] =
-                                           minimumValue;
+        for (int idx_edge = 0; idx_edge < deltaS[i].size(); idx_edge++) {
+            impalib_type min_val = zero_value;
+            min_val = min(forward[deltaS[i][idx_edge]], backward[deltaS[i][idx_edge] + 1]);
+            min_val = min(-min_val, zero_value);
+            subtour2edge[i][deltaS[i][idx_edge]] = min_val;
         }
     }
 }
@@ -113,55 +90,34 @@ void SubtourEliminationConstraint::subtour_constraints_to_edge_ec_update(
  * Process filtering on messages from subtour elimination constraints to edge equality constraints for the TSP
  *
  * @param[in] iter: index of iteration of IMPA
- * @param[in] rSubtourConstraints2EdgeEcDummyM: messages from subtour elimination constraints to edge equality constraints before filtering
- * @param[out] rSubtourConstraints2EdgeEcM: messages from subtour elimination constraints to edge equality constraints after filtering
- * @param[in] rDeltaSIndicesList: list of sub-list of indices. Each sub-list is asscoiated with a subtour constraint, and contains indices of edges related to this constraint
- * 
+ * @param[in] subtour2edge_in: messages from subtour elimination constraints to edge equality constraints before filtering
+ * @param[out] subtour2edge_out: messages from subtour elimination constraints to edge equality constraints after filtering
+ * @param[in] deltaS: list of sub-list of indices. Each sub-list is asscoiated with a subtour constraint, and contains indices of edges related to this constraint
+ *
  */
 
-void SubtourEliminationConstraint::process_filtering(const int                           iter,
-                                                     const vector<vector<impalib_type>> &rSubtourConstraints2EdgeEcDummyM,
-                                                     vector<vector<impalib_type>> &rSubtourConstraints2EdgeEcM,
-                                                     const vector<vector<int>>          &rDeltaSIndicesList)
-{
-
-    for (int i = 0; i < rDeltaSIndicesList.size(); i++)
-    {
-
-        if ((filteringFlag_) and (alpha_ != zero_value))
-        {
-            vector<impalib_type> intermediate_dummy(rSubtourConstraints2EdgeEcDummyM[i]),
-                intermediate_old(subtourConstraints2EdgeEcOld_[i]), intermediate_extrinsic;
+void SubtourEliminationConstraint::process_filtering(const int iter, const vector<vector<impalib_type>> &subtour2edge_in, vector<vector<impalib_type>> &subtour2edge_out,
+                                                     const vector<vector<int>> &deltaS) {
+    for (int i = 0; i < deltaS.size(); i++) {
+        if ((doFilter) and (alpha_ != zero_value)) {
+            vector<impalib_type> temp(subtour2edge_in[i]), temp_old(M_subtour2edge_old[i]), temp_extrinsic;
 
             impalib_type w_1 = alpha_, w_2 = 1 - alpha_;
-            transform(intermediate_dummy.begin(), intermediate_dummy.end(), intermediate_dummy.begin(),
-                      [w_2](impalib_type &c) { return c * w_2; });
-            transform(intermediate_old.begin(), intermediate_old.end(), intermediate_old.begin(),
-                      [w_1](impalib_type &c) { return c * w_1; });
+            transform(temp.begin(), temp.end(), temp.begin(), [w_2](impalib_type &c) { return c * w_2; });
+            transform(temp_old.begin(), temp_old.end(), temp_old.begin(), [w_1](impalib_type &c) { return c * w_1; });
 
-            if (iter == 0)
-            {
-                copy(intermediate_dummy.begin(), intermediate_dummy.end(),
-                     rSubtourConstraints2EdgeEcM[i].begin());
-            }
-            else
-            {
-                transform(intermediate_dummy.begin(), intermediate_dummy.end(), intermediate_old.begin(),
-                          back_inserter(intermediate_extrinsic), plus<impalib_type>());
-                copy(intermediate_extrinsic.begin(), intermediate_extrinsic.end(),
-                     rSubtourConstraints2EdgeEcM[i].begin());
+            if (iter == 0) {
+                copy(temp.begin(), temp.end(), subtour2edge_out[i].begin());
+            } else {
+                transform(temp.begin(), temp.end(), temp_old.begin(), back_inserter(temp_extrinsic), plus<impalib_type>());
+                copy(temp_extrinsic.begin(), temp_extrinsic.end(), subtour2edge_out[i].begin());
             }
 
-            copy(rSubtourConstraints2EdgeEcM[i].begin(),
-                 rSubtourConstraints2EdgeEcM[i].end(),
-                 subtourConstraints2EdgeEcOld_[i].begin());
+            copy(subtour2edge_out[i].begin(), subtour2edge_out[i].end(), M_subtour2edge_old[i].begin());
         }
 
-        else
-        {
-            copy(rSubtourConstraints2EdgeEcDummyM[i].begin(),
-                 rSubtourConstraints2EdgeEcDummyM[i].end(),
-                 rSubtourConstraints2EdgeEcM[i].begin());
+        else {
+            copy(subtour2edge_in[i].begin(), subtour2edge_in[i].end(), subtour2edge_out[i].begin());
         }
     }
 }

--- a/include/impalib/subtour_elimination_constraint.hpp
+++ b/include/impalib/subtour_elimination_constraint.hpp
@@ -25,7 +25,7 @@ class SubtourEliminationConstraint {
    public:
     vector<vector<impalib_type>> M_subtour2edge_old;  ///< messages from subtour constraints to edge equality constraint before filtering
     void messages_to_edge_ec(const vector<vector<impalib_type>> &edge2subtour, const vector<vector<int>> &deltaS,
-                             vector<vector<impalib_type>> &subtour2edge);  ///< calculate messages from subtour to edge equality constraints
+                             vector<vector<impalib_type>> &subtour2edge) const;  ///< calculate messages from subtour to edge equality constraints
     vector<vector<impalib_type>> process_filtering(int, const vector<vector<impalib_type>> &,
                                                    const vector<vector<int>> &);  ///< perform filtering on messages from subtour to edge equality constraints
 
@@ -52,7 +52,7 @@ inline SubtourEliminationConstraint::SubtourEliminationConstraint(const int NUM_
  * @param[out] subtour2edge: messages from subtour elimination constraints to edge equality constraints
  *
  */
-inline void SubtourEliminationConstraint::messages_to_edge_ec(const vector<vector<impalib_type>> &edge2subtour, const vector<vector<int>> &deltaS, vector<vector<impalib_type>> &subtour2edge) {
+inline void SubtourEliminationConstraint::messages_to_edge_ec(const vector<vector<impalib_type>> &edge2subtour, const vector<vector<int>> &deltaS, vector<vector<impalib_type>> &subtour2edge) const {
     vector<impalib_type> forward(n_Edges + 1, zero_value);
     vector<impalib_type> backward(n_Edges + 1, zero_value);
 

--- a/include/impalib/update_degree_constraint.hpp
+++ b/include/impalib/update_degree_constraint.hpp
@@ -48,15 +48,9 @@ public:
 
 DegreeConstraint::DegreeConstraint(const int NUM_NODES, const int NUM_EDGE_VARIABLES, const bool FILTERING_FLAG,
                                    const impalib_type ALPHA)
-    : filteringFlag_(FILTERING_FLAG), alpha_(ALPHA), numNodes_(NUM_NODES), numEdgeVariables_(NUM_EDGE_VARIABLES)
+    : filteringFlag_(FILTERING_FLAG), alpha_(ALPHA), numNodes_(NUM_NODES), numEdgeVariables_(NUM_EDGE_VARIABLES),
+      degreeConstraint2EqConstraintOld(numEdgeVariables_, vector<impalib_type>(numNodes_, 0))
 {
-
-    degreeConstraint2EqConstraintOld.reserve(numEdgeVariables_);
-    for (int edge_variable_index = 0; edge_variable_index < numEdgeVariables_; edge_variable_index++)
-    {
-        degreeConstraint2EqConstraintOld.push_back(vector<impalib_type>(numNodes_, zero_value));
-    }
-
     // Set initial forward and backward messages to infinity
     initial_forward_message_  = value_inf;
     initial_backward_message_ = value_inf;

--- a/include/impalib/update_degree_constraint.hpp
+++ b/include/impalib/update_degree_constraint.hpp
@@ -51,10 +51,7 @@ DegreeConstraint::DegreeConstraint(const int NUM_NODES, const int NUM_EDGE_VARIA
     : filteringFlag_(FILTERING_FLAG), alpha_(ALPHA), numNodes_(NUM_NODES), numEdgeVariables_(NUM_EDGE_VARIABLES)
 {
 
-    // Reserve space for old degree constraint to equality constraint messages
     degreeConstraint2EqConstraintOld.reserve(numEdgeVariables_);
-
-    // Initialize old degree constraint to equality constraint messages
     for (int edge_variable_index = 0; edge_variable_index < numEdgeVariables_; edge_variable_index++)
     {
         degreeConstraint2EqConstraintOld.push_back(vector<impalib_type>(numNodes_, zero_value));
@@ -78,17 +75,14 @@ void DegreeConstraint::degree_constraint_to_edge_ec_update(
     vector<vector<impalib_type>> &rEdgeEc2DegreeConstraintM, vector<vector<int>> &rEdgeConnections,
     vector<vector<impalib_type>> &rDegreeConstraint2EqConstraintDummyM)
 {
-    // Initialize vectors to store forward and backward messages
     vector<impalib_type> stage_forward_messages(numEdgeVariables_ + 1, zero_value);
     vector<impalib_type> stage_backward_messages(numEdgeVariables_ + 1, zero_value);
 
-    // Iterate over each node
     for (int node_index = 0; node_index < numNodes_; node_index++)
     {
-        // Initialize vectors to store connections of the current node
         vector<int> connections_first, connections_second;
 
-        // Populate connections_first and connections_second with edge indices based on the current node
+        // Populate connections_first and connections_second with edge indices
         for (int i = 0; i < rEdgeConnections.size(); i++)
         {
             if (node_index == rEdgeConnections[i][0])
@@ -122,7 +116,6 @@ void DegreeConstraint::degree_constraint_to_edge_ec_update(
                     rEdgeEc2DegreeConstraintM[connections_first[stage]][node_index]);
         }
 
-        // Update rDegreeConstraint2EqConstraintDummyM for connections_first
         for (int index_edge_variable = 0; index_edge_variable < connections_first.size(); index_edge_variable++)
         {
             impalib_type minimumValue = zero_value;
@@ -131,11 +124,9 @@ void DegreeConstraint::degree_constraint_to_edge_ec_update(
             rDegreeConstraint2EqConstraintDummyM[connections_first[index_edge_variable]][node_index] = -minimumValue;
         }
 
-        // Reset stage_forward_messages and stage_backward_messages
         fill(stage_forward_messages.begin(), stage_forward_messages.end(), zero_value);
         fill(stage_backward_messages.begin(), stage_backward_messages.end(), zero_value);
 
-        // Similar calculations for connections_second
         // Calculate forward messages
         stage_forward_messages[connections_second[0]] = initial_forward_message_;
 
@@ -157,7 +148,6 @@ void DegreeConstraint::degree_constraint_to_edge_ec_update(
                     rEdgeEc2DegreeConstraintM[connections_second[stage]][node_index]);
         }
 
-        // Update rDegreeConstraint2EqConstraintDummyM for connections_second
         for (int index_edge_variable = 0; index_edge_variable < connections_second.size(); index_edge_variable++)
         {
             impalib_type minimumValue = zero_value;
@@ -180,10 +170,8 @@ void DegreeConstraint::degree_constraint_to_edge_ec_update(
 void DegreeConstraint::process_filtering(int iter, vector<vector<impalib_type>> &rDegreeConstraint2EqConstraintDummyM,
                                          vector<vector<impalib_type>> &rDegreeConstraint2EqConstraintM)
 {
-    // Iterate over each edge variable
     for (int edge_variable_index = 0; edge_variable_index < numEdgeVariables_; edge_variable_index++)
     {
-        // Check if filtering is enabled and alpha is not zero
         if ((filteringFlag_) and (alpha_ != zero_value))
         {
             // Calculate weighted values for current and old messages
@@ -195,7 +183,7 @@ void DegreeConstraint::process_filtering(int iter, vector<vector<impalib_type>> 
                       [w_2](impalib_type &c) { return c * w_2; });
             transform(intermediate_old.begin(), intermediate_old.end(), intermediate_old.begin(),
                       [w_1](impalib_type &c) { return c * w_1; });
-            // Update messages based on iteration
+
             if (iter == 0)
             {
                 copy(intermediate_dummy.begin(), intermediate_dummy.end(),
@@ -208,13 +196,11 @@ void DegreeConstraint::process_filtering(int iter, vector<vector<impalib_type>> 
                 copy(intermediate_extrinsic.begin(), intermediate_extrinsic.end(),
                      rDegreeConstraint2EqConstraintM[edge_variable_index].begin());
             }
-            // Update old messages with current messages
             copy(rDegreeConstraint2EqConstraintM[edge_variable_index].begin(),
                  rDegreeConstraint2EqConstraintM[edge_variable_index].end(),
                  degreeConstraint2EqConstraintOld[edge_variable_index].begin());
         }
 
-        // If filtering is not enabled or alpha is zero, copy dummy messages to current messages
         else
         {
             copy(rDegreeConstraint2EqConstraintDummyM[edge_variable_index].begin(),

--- a/include/impalib/update_degree_constraint.hpp
+++ b/include/impalib/update_degree_constraint.hpp
@@ -78,50 +78,50 @@ void DegreeConstraint::degree_constraint_to_edge_ec_update(
     vector<impalib_type> stage_forward_messages(numEdgeVariables_ + 1, zero_value);
     vector<impalib_type> stage_backward_messages(numEdgeVariables_ + 1, zero_value);
 
-    for (int node_index = 0; node_index < numNodes_; node_index++)
+    for (int i = 0; i < numNodes_; i++)
     {
         vector<int> connections_first, connections_second;
 
         // Populate connections_first and connections_second with edge indices
-        for (int i = 0; i < rEdgeConnections.size(); i++)
+        for (int j = 0; j < rEdgeConnections.size(); j++)
         {
-            if (node_index == rEdgeConnections[i][0])
+            if (i == rEdgeConnections[j][0])
             {
-                connections_first.push_back(i);
+                connections_first.push_back(j);
             }
-            else if (node_index == rEdgeConnections[i][1])
+            else if (i == rEdgeConnections[j][1])
             {
-                connections_second.push_back(i);
+                connections_second.push_back(j);
             }
         }
 
         // Calculate forward messages for connections_first
         stage_forward_messages[connections_first[0]] = initial_forward_message_;
 
-        for (int stage = 1; stage < connections_first.size(); stage++)
+        for (int s = 1; s < connections_first.size(); s++)
         {
 
-            stage_forward_messages[connections_first[stage]] =
-                min(stage_forward_messages[connections_first[stage - 1]],
-                    rEdgeEc2DegreeConstraintM[connections_first[stage - 1]][node_index]);
+            stage_forward_messages[connections_first[s]] =
+                min(stage_forward_messages[connections_first[s - 1]],
+                    rEdgeEc2DegreeConstraintM[connections_first[s - 1]][i]);
         }
 
         // Calculate backward messages for connections_first
         stage_backward_messages[connections_first[connections_first.size() - 1] + 1] = initial_backward_message_;
 
-        for (size_t stage = connections_first.size() - 1; stage >= 1; stage--)
+        for (size_t s = connections_first.size() - 1; s >= 1; s--)
         {
-            stage_backward_messages[connections_first[stage - 1] + 1] =
-                min(stage_backward_messages[connections_first[stage] + 1],
-                    rEdgeEc2DegreeConstraintM[connections_first[stage]][node_index]);
+            stage_backward_messages[connections_first[s - 1] + 1] =
+                min(stage_backward_messages[connections_first[s] + 1],
+                    rEdgeEc2DegreeConstraintM[connections_first[s]][i]);
         }
 
-        for (int index_edge_variable = 0; index_edge_variable < connections_first.size(); index_edge_variable++)
+        for (int j = 0; j < connections_first.size(); j++)
         {
             impalib_type minimumValue = zero_value;
-            minimumValue              = min(stage_forward_messages[connections_first[index_edge_variable]],
-                                            stage_backward_messages[connections_first[index_edge_variable] + 1]);
-            rDegreeConstraint2EqConstraintDummyM[connections_first[index_edge_variable]][node_index] = -minimumValue;
+            minimumValue              = min(stage_forward_messages[connections_first[j]],
+                                            stage_backward_messages[connections_first[j] + 1]);
+            rDegreeConstraint2EqConstraintDummyM[connections_first[j]][i] = -minimumValue;
         }
 
         fill(stage_forward_messages.begin(), stage_forward_messages.end(), zero_value);
@@ -130,30 +130,30 @@ void DegreeConstraint::degree_constraint_to_edge_ec_update(
         // Calculate forward messages
         stage_forward_messages[connections_second[0]] = initial_forward_message_;
 
-        for (int stage = 1; stage < connections_second.size(); stage++)
+        for (int s = 1; s < connections_second.size(); s++)
         {
 
-            stage_forward_messages[connections_second[stage]] =
-                min(stage_forward_messages[connections_second[stage - 1]],
-                    rEdgeEc2DegreeConstraintM[connections_second[stage - 1]][node_index]);
+            stage_forward_messages[connections_second[s]] =
+                min(stage_forward_messages[connections_second[s - 1]],
+                    rEdgeEc2DegreeConstraintM[connections_second[s - 1]][i]);
         }
 
         // Calculate backward messages
         stage_backward_messages[connections_second[connections_second.size() - 1] + 1] = initial_backward_message_;
 
-        for (size_t stage = connections_second.size() - 1; stage >= 1; stage--)
+        for (size_t s = connections_second.size() - 1; s >= 1; s--)
         {
-            stage_backward_messages[connections_second[stage - 1] + 1] =
-                min(stage_backward_messages[connections_second[stage] + 1],
-                    rEdgeEc2DegreeConstraintM[connections_second[stage]][node_index]);
+            stage_backward_messages[connections_second[s - 1] + 1] =
+                min(stage_backward_messages[connections_second[s] + 1],
+                    rEdgeEc2DegreeConstraintM[connections_second[s]][i]);
         }
 
-        for (int index_edge_variable = 0; index_edge_variable < connections_second.size(); index_edge_variable++)
+        for (int j = 0; j < connections_second.size(); j++)
         {
             impalib_type minimumValue = zero_value;
-            minimumValue              = min(stage_forward_messages[connections_second[index_edge_variable]],
-                                            stage_backward_messages[connections_second[index_edge_variable] + 1]);
-            rDegreeConstraint2EqConstraintDummyM[connections_second[index_edge_variable]][node_index] = -minimumValue;
+            minimumValue              = min(stage_forward_messages[connections_second[j]],
+                                            stage_backward_messages[connections_second[j] + 1]);
+            rDegreeConstraint2EqConstraintDummyM[connections_second[j]][i] = -minimumValue;
         }
     }
 }
@@ -170,13 +170,13 @@ void DegreeConstraint::degree_constraint_to_edge_ec_update(
 void DegreeConstraint::process_filtering(int iter, vector<vector<impalib_type>> &rDegreeConstraint2EqConstraintDummyM,
                                          vector<vector<impalib_type>> &rDegreeConstraint2EqConstraintM)
 {
-    for (int edge_variable_index = 0; edge_variable_index < numEdgeVariables_; edge_variable_index++)
+    for (int i = 0; i < numEdgeVariables_; i++)
     {
         if ((filteringFlag_) and (alpha_ != zero_value))
         {
             // Calculate weighted values for current and old messages
-            vector<impalib_type> intermediate_dummy(rDegreeConstraint2EqConstraintDummyM[edge_variable_index]),
-                intermediate_old(degreeConstraint2EqConstraintOld[edge_variable_index]), intermediate_extrinsic;
+            vector<impalib_type> intermediate_dummy(rDegreeConstraint2EqConstraintDummyM[i]),
+                intermediate_old(degreeConstraint2EqConstraintOld[i]), intermediate_extrinsic;
 
             impalib_type w_1 = alpha_, w_2 = 1 - alpha_;
             transform(intermediate_dummy.begin(), intermediate_dummy.end(), intermediate_dummy.begin(),
@@ -187,25 +187,25 @@ void DegreeConstraint::process_filtering(int iter, vector<vector<impalib_type>> 
             if (iter == 0)
             {
                 copy(intermediate_dummy.begin(), intermediate_dummy.end(),
-                     rDegreeConstraint2EqConstraintM[edge_variable_index].begin());
+                     rDegreeConstraint2EqConstraintM[i].begin());
             }
             else
             {
                 transform(intermediate_dummy.begin(), intermediate_dummy.end(), intermediate_old.begin(),
                           back_inserter(intermediate_extrinsic), plus<impalib_type>());
                 copy(intermediate_extrinsic.begin(), intermediate_extrinsic.end(),
-                     rDegreeConstraint2EqConstraintM[edge_variable_index].begin());
+                     rDegreeConstraint2EqConstraintM[i].begin());
             }
-            copy(rDegreeConstraint2EqConstraintM[edge_variable_index].begin(),
-                 rDegreeConstraint2EqConstraintM[edge_variable_index].end(),
-                 degreeConstraint2EqConstraintOld[edge_variable_index].begin());
+            copy(rDegreeConstraint2EqConstraintM[i].begin(),
+                 rDegreeConstraint2EqConstraintM[i].end(),
+                 degreeConstraint2EqConstraintOld[i].begin());
         }
 
         else
         {
-            copy(rDegreeConstraint2EqConstraintDummyM[edge_variable_index].begin(),
-                 rDegreeConstraint2EqConstraintDummyM[edge_variable_index].end(),
-                 rDegreeConstraint2EqConstraintM[edge_variable_index].begin());
+            copy(rDegreeConstraint2EqConstraintDummyM[i].begin(),
+                 rDegreeConstraint2EqConstraintDummyM[i].end(),
+                 rDegreeConstraint2EqConstraintM[i].begin());
         }
     }
 }

--- a/include/impalib/update_degree_constraint.hpp
+++ b/include/impalib/update_degree_constraint.hpp
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <cassert>
+#include <optional>
 
 #include "impalib/impalib.hpp"
 
@@ -22,9 +23,8 @@ class DegreeConstraint {
     vector<vector<impalib_type>> M_deg2eq_old;  ///< messages from degree constraints to equality constraints before filtering
 
    public:
-    void messages_to_edge_ec(const vector<vector<impalib_type>> &edge2degree, const vector<vector<int>> &edges,
-                             vector<vector<impalib_type>> &degree2eq);                                        ///< calculate messages from degree constraint to edge equality constraint
-    vector<vector<impalib_type>> process_filtering(int iter, const vector<vector<impalib_type>> &deg2eq_in);  ///< process filtering on messages from degree constraint to edge equality constraint
+    vector<vector<impalib_type>> messages_to_edge_ec(const vector<vector<impalib_type>> &edge2degree, const vector<vector<int>> &edges);                                        ///< calculate messages from degree constraint to edge equality constraint
+    vector<vector<impalib_type>> process_filtering(const vector<vector<impalib_type>> &deg2eq_in);  ///< process filtering on messages from degree constraint to edge equality constraint
 
     DegreeConstraint(int NUM_NODES, int NUM_EDGE_VARIABLES, bool FILTERING_FLAG,
                      impalib_type ALPHA);  ///< constructor
@@ -55,9 +55,11 @@ DegreeConstraint::DegreeConstraint(const int NUM_NODES, const int NUM_EDGE_VARIA
  *
  */
 
-void DegreeConstraint::messages_to_edge_ec(const vector<vector<impalib_type>> &edge2degree, const vector<vector<int>> &edges, vector<vector<impalib_type>> &degree2eq) {
+vector<vector<impalib_type>> DegreeConstraint::messages_to_edge_ec(const vector<vector<impalib_type>> &edge2degree, const vector<vector<int>> &edges) {
     static const impalib_type M_forward_init = value_inf;    ///< initial forward message of forward-backward algorithm
     static const impalib_type M_backward_init = value_inf;   ///< initial backward message of forward-backward algorithm
+
+    vector<vector<impalib_type>> degree2eq(numEdgeVariables_, vector<impalib_type>(numNodes_, 0));
 
     vector<impalib_type> forward(numEdgeVariables_ + 1, zero_value);
     vector<impalib_type> backward(numEdgeVariables_ + 1, zero_value);
@@ -117,6 +119,7 @@ void DegreeConstraint::messages_to_edge_ec(const vector<vector<impalib_type>> &e
             degree2eq[second[j]][i] = -minimumValue;
         }
     }
+    return degree2eq;
 }
 
 /**
@@ -128,7 +131,7 @@ void DegreeConstraint::messages_to_edge_ec(const vector<vector<impalib_type>> &e
  *
  */
 
-vector<vector<impalib_type>> DegreeConstraint::process_filtering(const int iter, const vector<vector<impalib_type>> &deg2eq_in) {
+vector<vector<impalib_type>> DegreeConstraint::process_filtering(const vector<vector<impalib_type>> &deg2eq_in) {
     assert(deg2eq_in.size() == numEdgeVariables_);
     if (!filteringFlag_) {
         return deg2eq_in;

--- a/include/impalib/update_degree_constraint.hpp
+++ b/include/impalib/update_degree_constraint.hpp
@@ -23,7 +23,7 @@ class DegreeConstraint {
     vector<vector<impalib_type>> M_deg2eq_old;  ///< messages from degree constraints to equality constraints before filtering
 
    public:
-    vector<vector<impalib_type>> messages_to_edge_ec(const vector<vector<impalib_type>> &edge2degree, const vector<vector<int>> &edges);                                        ///< calculate messages from degree constraint to edge equality constraint
+    vector<vector<impalib_type>> messages_to_edge_ec(const vector<vector<impalib_type>> &edge2degree, const vector<vector<int>> &edges) const;                                        ///< calculate messages from degree constraint to edge equality constraint
     vector<vector<impalib_type>> process_filtering(const vector<vector<impalib_type>> &deg2eq_in);  ///< process filtering on messages from degree constraint to edge equality constraint
 
     DegreeConstraint(int NUM_NODES, int NUM_EDGE_VARIABLES, bool FILTERING_FLAG,
@@ -49,7 +49,7 @@ inline DegreeConstraint::DegreeConstraint(const int NUM_NODES, const int NUM_EDG
  * @returns: messages from degree constraints to edge equality constraints before filtering
  *
  */
-inline vector<vector<impalib_type>> DegreeConstraint::messages_to_edge_ec(const vector<vector<impalib_type>> &edge2degree, const vector<vector<int>> &edges) {
+inline vector<vector<impalib_type>> DegreeConstraint::messages_to_edge_ec(const vector<vector<impalib_type>> &edge2degree, const vector<vector<int>> &edges) const {
     static const impalib_type M_forward_init = value_inf;    ///< initial forward message of forward-backward algorithm
     static const impalib_type M_backward_init = value_inf;   ///< initial backward message of forward-backward algorithm
 

--- a/include/impalib/update_degree_constraint.hpp
+++ b/include/impalib/update_degree_constraint.hpp
@@ -23,12 +23,12 @@ private:
     impalib_type                 initial_backward_message_ = value_inf; ///< initial backward message of forward-backward algorithm
 
 public:
-    void degree_constraint_to_edge_ec_update(vector<vector<impalib_type>> &, vector<vector<int>> &,
+    void degree_constraint_to_edge_ec_update(const vector<vector<impalib_type>> &, const vector<vector<int>> &,
                                              vector<vector<impalib_type>> &); ///< calculate messages from degree constraint to edge equality constraint
-    void process_filtering(int, vector<vector<impalib_type>> &, vector<vector<impalib_type>> &); ///< process filtering on messages from degree constraint to edge equality constraint
+    void process_filtering(int, const vector<vector<impalib_type>> &, vector<vector<impalib_type>> &); ///< process filtering on messages from degree constraint to edge equality constraint
 
-    DegreeConstraint(const int NUM_NODES, const int NUM_EDGE_VARIABLES, const bool FILTERING_FLAG,
-                     const impalib_type ALPHA); ///< constructor
+    DegreeConstraint(int NUM_NODES, int NUM_EDGE_VARIABLES, bool FILTERING_FLAG,
+                     impalib_type ALPHA); ///< constructor
 };
 
 /**
@@ -61,7 +61,7 @@ DegreeConstraint::DegreeConstraint(const int NUM_NODES, const int NUM_EDGE_VARIA
  */
 
 void DegreeConstraint::degree_constraint_to_edge_ec_update(
-    vector<vector<impalib_type>> &rEdgeEc2DegreeConstraintM, vector<vector<int>> &rEdgeConnections,
+    const vector<vector<impalib_type>> &rEdgeEc2DegreeConstraintM, const vector<vector<int>> &rEdgeConnections,
     vector<vector<impalib_type>> &rDegreeConstraint2EqConstraintDummyM)
 {
     vector<impalib_type> stage_forward_messages(numEdgeVariables_ + 1, zero_value);
@@ -156,7 +156,7 @@ void DegreeConstraint::degree_constraint_to_edge_ec_update(
  * 
  */
 
-void DegreeConstraint::process_filtering(int iter, vector<vector<impalib_type>> &rDegreeConstraint2EqConstraintDummyM,
+void DegreeConstraint::process_filtering(const int iter, const vector<vector<impalib_type>> &rDegreeConstraint2EqConstraintDummyM,
                                          vector<vector<impalib_type>> &rDegreeConstraint2EqConstraintM)
 {
     for (int i = 0; i < numEdgeVariables_; i++)

--- a/include/impalib/update_degree_constraint.hpp
+++ b/include/impalib/update_degree_constraint.hpp
@@ -37,13 +37,8 @@ class DegreeConstraint {
  * @param[in] NUM_EDGE_VARIABLES: number of connections between nodes
  * @param[in] FILTERING_FLAG: filtering on or off
  * @param[in] ALPHA: filtering parameter value (between 0 and 1)
- * @param[out] filteringFlag_: FILTERING_FLAG
- * @param[out] alpha_: ALPHA
- * @param[out] numNodes_: NUM_NODES
- * @param[out] numEdgeVariables_: NUM_EDGE_VARIABLES
  */
-
-DegreeConstraint::DegreeConstraint(const int NUM_NODES, const int NUM_EDGE_VARIABLES, const bool FILTERING_FLAG, const impalib_type ALPHA)
+inline DegreeConstraint::DegreeConstraint(const int NUM_NODES, const int NUM_EDGE_VARIABLES, const bool FILTERING_FLAG, const impalib_type ALPHA)
     : filteringFlag_(FILTERING_FLAG), alpha_(ALPHA), numNodes_(NUM_NODES), numEdgeVariables_(NUM_EDGE_VARIABLES), M_deg2eq_old(numEdgeVariables_, vector<impalib_type>(numNodes_, 0)){};
 
 /**
@@ -51,11 +46,10 @@ DegreeConstraint::DegreeConstraint(const int NUM_NODES, const int NUM_EDGE_VARIA
  *
  * @param[in] edge2degree: messages from edge equality constraints to degree constraints
  * @param[in] edges: list of connections for each edge equality constraint
- * @param[out] degree2eq: messages from degree constraints to edge equality constraints before filtering
+ * @returns: messages from degree constraints to edge equality constraints before filtering
  *
  */
-
-vector<vector<impalib_type>> DegreeConstraint::messages_to_edge_ec(const vector<vector<impalib_type>> &edge2degree, const vector<vector<int>> &edges) {
+inline vector<vector<impalib_type>> DegreeConstraint::messages_to_edge_ec(const vector<vector<impalib_type>> &edge2degree, const vector<vector<int>> &edges) {
     static const impalib_type M_forward_init = value_inf;    ///< initial forward message of forward-backward algorithm
     static const impalib_type M_backward_init = value_inf;   ///< initial backward message of forward-backward algorithm
 
@@ -125,13 +119,11 @@ vector<vector<impalib_type>> DegreeConstraint::messages_to_edge_ec(const vector<
 /**
  * Perform filtering on messages from degree constraints to edge equality constraints for the TSP
  *
- * @param[in] iter: iteration index of IMPA
  * @param[in] deg2eq_in: messages from degree constraints to edge equality constraints before filtering
- * @param[in] deg2eq_out: messages from degree constraints to edge equality constraints after filtering
+ * @returns: messages from degree constraints to edge equality constraints after filtering
  *
  */
-
-vector<vector<impalib_type>> DegreeConstraint::process_filtering(const vector<vector<impalib_type>> &deg2eq_in) {
+inline vector<vector<impalib_type>> DegreeConstraint::process_filtering(const vector<vector<impalib_type>> &deg2eq_in) {
     assert(deg2eq_in.size() == numEdgeVariables_);
     if (!filteringFlag_) {
         return deg2eq_in;

--- a/include/impalib/update_degree_constraint.hpp
+++ b/include/impalib/update_degree_constraint.hpp
@@ -19,10 +19,8 @@ private:
     bool                         filteringFlag_; ///< filtering flag
     impalib_type                 alpha_; ///< filtering parameter
     vector<vector<impalib_type>> degreeConstraint2EqConstraintOld; ///< messages from degree constraints to equality constraints before filtering
-    impalib_type                 initial_forward_message_; ///< initial forward message of forward-backward algorithm
-    impalib_type                 initial_backward_message_; ///< initial backward message of forward-backward algorithm
-    vector<vector<impalib_type>> stage_forward_messages; ///< forward messages of trellis representation
-    vector<vector<impalib_type>> stage_backward_messages; ///< backward messages of trellis representation
+    impalib_type                 initial_forward_message_ = value_inf; ///< initial forward message of forward-backward algorithm
+    impalib_type                 initial_backward_message_ = value_inf; ///< initial backward message of forward-backward algorithm
 
 public:
     void degree_constraint_to_edge_ec_update(vector<vector<impalib_type>> &, vector<vector<int>> &,
@@ -51,9 +49,6 @@ DegreeConstraint::DegreeConstraint(const int NUM_NODES, const int NUM_EDGE_VARIA
     : filteringFlag_(FILTERING_FLAG), alpha_(ALPHA), numNodes_(NUM_NODES), numEdgeVariables_(NUM_EDGE_VARIABLES),
       degreeConstraint2EqConstraintOld(numEdgeVariables_, vector<impalib_type>(numNodes_, 0))
 {
-    // Set initial forward and backward messages to infinity
-    initial_forward_message_  = value_inf;
-    initial_backward_message_ = value_inf;
 };
 
 /**

--- a/include/impalib/update_degree_constraint.hpp
+++ b/include/impalib/update_degree_constraint.hpp
@@ -20,8 +20,6 @@ class DegreeConstraint {
     bool filteringFlag_;                        ///< filtering flag
     impalib_type alpha_;                        ///< filtering parameter
     vector<vector<impalib_type>> M_deg2eq_old;  ///< messages from degree constraints to equality constraints before filtering
-    impalib_type M_forward_init = value_inf;    ///< initial forward message of forward-backward algorithm
-    impalib_type M_backward_init = value_inf;   ///< initial backward message of forward-backward algorithm
 
    public:
     void messages_to_edge_ec(const vector<vector<impalib_type>> &edge2degree, const vector<vector<int>> &edges,
@@ -58,6 +56,9 @@ DegreeConstraint::DegreeConstraint(const int NUM_NODES, const int NUM_EDGE_VARIA
  */
 
 void DegreeConstraint::messages_to_edge_ec(const vector<vector<impalib_type>> &edge2degree, const vector<vector<int>> &edges, vector<vector<impalib_type>> &degree2eq) {
+    static const impalib_type M_forward_init = value_inf;    ///< initial forward message of forward-backward algorithm
+    static const impalib_type M_backward_init = value_inf;   ///< initial backward message of forward-backward algorithm
+
     vector<impalib_type> forward(numEdgeVariables_ + 1, zero_value);
     vector<impalib_type> backward(numEdgeVariables_ + 1, zero_value);
 

--- a/include/impalib/update_equality_constraint.hpp
+++ b/include/impalib/update_equality_constraint.hpp
@@ -20,7 +20,7 @@ class EqualityConstraintKcMwm {
     vector<impalib_type> team_messages_to_oric(const vector<vector<impalib_type>> &extrinsic,
                                                const vector<impalib_type> &reward_team);  ///< calculate messages from team equality constraint to ORIC
 
-    void project_messages_to_oric(const vector<vector<impalib_type>> &proj2eq, vector<vector<impalib_type>> &eq2oric,
+    vector<vector<impalib_type>> project_messages_to_oric(const vector<vector<impalib_type>> &proj2eq,
                                   const vector<vector<impalib_type>> &reward_proj);  ///< calculate messages from project equality constraint to ORIC
 
     EqualityConstraintKcMwm(int N_DEPARTMENTS, int N_TEAMS, int N_PROJECTS);  ///< constructor
@@ -65,10 +65,12 @@ vector<impalib_type> EqualityConstraintKcMwm::team_messages_to_oric(const vector
  * @param[in] reward_proj: rewards of teams-projects combinations
  */
 
-void EqualityConstraintKcMwm::project_messages_to_oric(const vector<vector<impalib_type>> &proj2eq, vector<vector<impalib_type>> &eq2oric, const vector<vector<impalib_type>> &reward_proj) {
+vector<vector<impalib_type>> EqualityConstraintKcMwm::project_messages_to_oric(const vector<vector<impalib_type>> &proj2eq, const vector<vector<impalib_type>> &reward_proj) {
+    vector<vector<impalib_type>> eq2oric(proj2eq.size());
     for (int i = 0; i < proj2eq.size(); i++) {
         transform(proj2eq[i].begin(), proj2eq[i].end(), reward_proj[i].begin(), eq2oric[i].begin(), std::plus<impalib_type>());
     }
+    return eq2oric;
 }
 
 /**

--- a/include/impalib/update_equality_constraint.hpp
+++ b/include/impalib/update_equality_constraint.hpp
@@ -18,8 +18,7 @@ private:
     int numDepartments_; ///< number of departments
 
 public:
-    void team_eq_constraint_to_oric_update(const vector<vector<impalib_type>> &, vector<impalib_type> &,
-                                           const vector<impalib_type> &); ///< calculate messages from team equality constraint to ORIC
+    vector<impalib_type> team_eq_constraint_to_oric_update(const vector<vector<impalib_type>> &, const vector<impalib_type> &); ///< calculate messages from team equality constraint to ORIC
 
     void project_eq_constraint_to_oric_update(const vector<vector<impalib_type>> &, vector<vector<impalib_type>> &,
                                               const vector<vector<impalib_type>> &); ///< calculate messages from project equality constraint to ORIC
@@ -50,20 +49,21 @@ EqualityConstraintKcMwm::EqualityConstraintKcMwm(int N_DEPARTMENTS, int N_TEAMS,
  * @param[in] rewardTeam: rewards of teams
  */
 
-void EqualityConstraintKcMwm::team_eq_constraint_to_oric_update(
-    const vector<vector<impalib_type>> &rExtrinsicOutputDepartment, vector<impalib_type> &rTeam2OricM,
+vector<impalib_type> EqualityConstraintKcMwm::team_eq_constraint_to_oric_update(
+    const vector<vector<impalib_type>> &rExtrinsicOutputDepartment,
     const vector<impalib_type> &rewardTeam)
 {
-    vector<impalib_type> intermediate_team_to_oric_m(numTeams_, 0);
+    vector<impalib_type> team2oric(numTeams_, 0);
 
     for (int i = 0; i < rExtrinsicOutputDepartment.size(); i++)
     {
         transform(rExtrinsicOutputDepartment[i].begin(),
-                  rExtrinsicOutputDepartment[i].end(), intermediate_team_to_oric_m.begin(),
-                  intermediate_team_to_oric_m.begin(), std::plus<impalib_type>());
+                  rExtrinsicOutputDepartment[i].end(), team2oric.begin(),
+                  team2oric.begin(), std::plus<impalib_type>());
     }
-    transform(intermediate_team_to_oric_m.begin(), intermediate_team_to_oric_m.end(), rewardTeam.begin(),
-              rTeam2OricM.begin(), std::plus<impalib_type>());
+    transform(team2oric.begin(), team2oric.end(), rewardTeam.begin(),
+              team2oric.begin(), std::plus<impalib_type>());
+    return team2oric;
 }
 
 /**

--- a/include/impalib/update_equality_constraint.hpp
+++ b/include/impalib/update_equality_constraint.hpp
@@ -18,9 +18,9 @@ class EqualityConstraintKcMwm {
 
    public:
     vector<impalib_type> team_messages_to_oric(const vector<vector<impalib_type>> &extrinsic,
-                                               const vector<impalib_type> &reward_team);  ///< calculate messages from team equality constraint to ORIC
+                                               const vector<impalib_type> &reward_team) const;  ///< calculate messages from team equality constraint to ORIC
 
-    vector<vector<impalib_type>> project_messages_to_oric(const vector<vector<impalib_type>> &proj2eq,
+    static vector<vector<impalib_type>> project_messages_to_oric(const vector<vector<impalib_type>> &proj2eq,
                                   const vector<vector<impalib_type>> &reward_proj);  ///< calculate messages from project equality constraint to ORIC
 
     EqualityConstraintKcMwm(int N_DEPARTMENTS, int N_TEAMS, int N_PROJECTS);  ///< constructor
@@ -33,7 +33,7 @@ class EqualityConstraintKcMwm {
  * @param[in] N_TEAMS: number of teams
  * @param[in] N_PROJECTS: number of projects
  */
-inline EqualityConstraintKcMwm::EqualityConstraintKcMwm(int N_DEPARTMENTS, int N_TEAMS, int N_PROJECTS) : numProjects_(N_PROJECTS), numTeams_(N_TEAMS), numDepartments_(N_DEPARTMENTS){};
+inline EqualityConstraintKcMwm::EqualityConstraintKcMwm(const int N_DEPARTMENTS, const int N_TEAMS, const int N_PROJECTS) : numProjects_(N_PROJECTS), numTeams_(N_TEAMS), numDepartments_(N_DEPARTMENTS){};
 
 /**
  * Calculate messages from team equality constraint to ORIC for the Knapsack-MWM problem
@@ -42,7 +42,7 @@ inline EqualityConstraintKcMwm::EqualityConstraintKcMwm(int N_DEPARTMENTS, int N
  * @param[in] reward_team: rewards of teams
  * @returns: messages from team equality constraint to ORIC
  */
-inline vector<impalib_type> EqualityConstraintKcMwm::team_messages_to_oric(const vector<vector<impalib_type>> &extrinsic, const vector<impalib_type> &reward_team) {
+inline vector<impalib_type> EqualityConstraintKcMwm::team_messages_to_oric(const vector<vector<impalib_type>> &extrinsic, const vector<impalib_type> &reward_team) const {
     vector<impalib_type> team2oric(numTeams_, 0);
 
     for (int i = 0; i < extrinsic.size(); i++) {
@@ -80,14 +80,14 @@ class EqualityConstraintTsp {
    public:
     void messages_to_degree_relaxed(const vector<vector<int>> &edges, const vector<vector<impalib_type>> &cost_edges, const vector<vector<impalib_type>> &deg2eq,
                                     vector<vector<impalib_type>> &edge2deg);                          ///< calculate messages from edge to degree constraints for relaxed TSP
-    vector<vector<impalib_type>> flip_matrix(const vector<vector<impalib_type>> &, const vector<vector<int>> &);  ///< flip matrix
+    static vector<vector<impalib_type>> flip_matrix(const vector<vector<impalib_type>> &, const vector<vector<int>> &);  ///< flip matrix
     vector<vector<impalib_type>> messages_to_subtour(const vector<vector<int>> &deltaS, const vector<impalib_type> &edge_costs, const vector<vector<impalib_type>> &deg2edge, const vector<vector<impalib_type>> &subtour2edge,
-                                                     const vector<vector<int>> &edges);  ///< calculate message from edge to subtour constraint
+                                                     const vector<vector<int>> &edges) const;  ///< calculate message from edge to subtour constraint
     void messages_to_degree_augmented(const vector<vector<impalib_type>> &deg2eq, const vector<vector<impalib_type>> &subtour2edge, const vector<vector<int>> &edges, const vector<vector<impalib_type>> &edge_costs,
-                                      vector<vector<impalib_type>> &edge2deg);  ///< calculate messages from edge to degree constraints for augmented TSP
+                                      vector<vector<impalib_type>> &edge2deg) const;  ///< calculate messages from edge to degree constraints for augmented TSP
 
-    EqualityConstraintTsp(const int NUM_NODES, const int NUM_EDGE_VARIABLES, const bool FILTERING_FLAG,
-                          const impalib_type ALPHA);  ///< constructor
+    EqualityConstraintTsp(int NUM_NODES, int NUM_EDGE_VARIABLES, bool FILTERING_FLAG,
+                          impalib_type ALPHA);  ///< constructor
 };
 
 /**
@@ -130,7 +130,7 @@ inline void EqualityConstraintTsp::messages_to_degree_relaxed(const vector<vecto
  *
  */
 inline vector<vector<impalib_type>> EqualityConstraintTsp::messages_to_subtour(const vector<vector<int>> &deltaS, const vector<impalib_type> &edge_costs, const vector<vector<impalib_type>> &deg2edge,
-                                                                        const vector<vector<impalib_type>> &subtour2edge, const vector<vector<int>> &edges) {
+                                                                        const vector<vector<impalib_type>> &subtour2edge, const vector<vector<int>> &edges) const {
     vector<vector<impalib_type>> edge2subtour_list;
 
     if (deltaS.size() == 1) {
@@ -181,7 +181,7 @@ inline vector<vector<impalib_type>> EqualityConstraintTsp::messages_to_subtour(c
  *
  */
 inline void EqualityConstraintTsp::messages_to_degree_augmented(const vector<vector<impalib_type>> &deg2eq, const vector<vector<impalib_type>> &subtour2edge, const vector<vector<int>> &edges,
-                                                         const vector<vector<impalib_type>> &edge_costs, vector<vector<impalib_type>> &edge2deg) {
+                                                         const vector<vector<impalib_type>> &edge_costs, vector<vector<impalib_type>> &edge2deg) const {
     vector<impalib_type> subtour2edge_sum(numEdgeVariables_, zero_value);
     for (const auto &row : subtour2edge) {
         transform(subtour2edge_sum.begin(), subtour2edge_sum.end(), row.begin(), subtour2edge_sum.begin(), std::plus<impalib_type>());

--- a/include/impalib/update_equality_constraint.hpp
+++ b/include/impalib/update_equality_constraint.hpp
@@ -18,13 +18,13 @@ private:
     int numDepartments_; ///< number of departments
 
 public:
-    void team_eq_constraint_to_oric_update(vector<vector<impalib_type>> &, vector<impalib_type> &,
-                                           vector<impalib_type> &); ///< calculate messages from team equality constraint to ORIC
+    void team_eq_constraint_to_oric_update(const vector<vector<impalib_type>> &, vector<impalib_type> &,
+                                           const vector<impalib_type> &); ///< calculate messages from team equality constraint to ORIC
 
-    void project_eq_constraint_to_oric_update(vector<vector<impalib_type>> &, vector<vector<impalib_type>> &,
-                                              vector<vector<impalib_type>> &); ///< calculate messages from project equality constraint to ORIC
+    void project_eq_constraint_to_oric_update(const vector<vector<impalib_type>> &, vector<vector<impalib_type>> &,
+                                              const vector<vector<impalib_type>> &); ///< calculate messages from project equality constraint to ORIC
 
-    EqualityConstraintKcMwm(const int N_DEPARTMENTS, const int N_TEAMS, const int N_PROJECTS); ///< constructor
+    EqualityConstraintKcMwm(int N_DEPARTMENTS, int N_TEAMS, int N_PROJECTS); ///< constructor
 };
 
 /**
@@ -51,8 +51,8 @@ EqualityConstraintKcMwm::EqualityConstraintKcMwm(int N_DEPARTMENTS, int N_TEAMS,
  */
 
 void EqualityConstraintKcMwm::team_eq_constraint_to_oric_update(
-    vector<vector<impalib_type>> &rExtrinsicOutputDepartment, vector<impalib_type> &rTeam2OricM,
-    vector<impalib_type> &rewardTeam)
+    const vector<vector<impalib_type>> &rExtrinsicOutputDepartment, vector<impalib_type> &rTeam2OricM,
+    const vector<impalib_type> &rewardTeam)
 {
     vector<impalib_type> intermediate_team_to_oric_m(numTeams_, 0);
 
@@ -74,9 +74,9 @@ void EqualityConstraintKcMwm::team_eq_constraint_to_oric_update(
  * @param[in] rewardProject: rewards of teams-projects combinations
  */
 
-void EqualityConstraintKcMwm::project_eq_constraint_to_oric_update(vector<vector<impalib_type>> &rProject2EqConstraintM,
+void EqualityConstraintKcMwm::project_eq_constraint_to_oric_update(const vector<vector<impalib_type>> &rProject2EqConstraintM,
                                                                    vector<vector<impalib_type>> &rEqConstraint2OricM,
-                                                                   vector<vector<impalib_type>> &rewardProject)
+                                                                   const vector<vector<impalib_type>> &rewardProject)
 {
     for (int i = 0; i < rProject2EqConstraintM.size(); i++)
     {

--- a/include/impalib/update_equality_constraint.hpp
+++ b/include/impalib/update_equality_constraint.hpp
@@ -10,20 +10,20 @@
 /**
  * Represents a class for the equality constraint for the Knapsack-MWM problem
  */
-class EqualityConstraintKcMwm
-{
-private:
-    int numTeams_; ///< number of teams
-    int numProjects_; ///< number of projects
-    int numDepartments_; ///< number of departments
+class EqualityConstraintKcMwm {
+   private:
+    int numTeams_;        ///< number of teams
+    int numProjects_;     ///< number of projects
+    int numDepartments_;  ///< number of departments
 
-public:
-    vector<impalib_type> team_eq_constraint_to_oric_update(const vector<vector<impalib_type>> &, const vector<impalib_type> &); ///< calculate messages from team equality constraint to ORIC
+   public:
+    vector<impalib_type> team_messages_to_oric(const vector<vector<impalib_type>> &extrinsic,
+                                               const vector<impalib_type> &reward_team);  ///< calculate messages from team equality constraint to ORIC
 
-    void project_eq_constraint_to_oric_update(const vector<vector<impalib_type>> &, vector<vector<impalib_type>> &,
-                                              const vector<vector<impalib_type>> &); ///< calculate messages from project equality constraint to ORIC
+    void project_messages_to_oric(const vector<vector<impalib_type>> &proj2eq, vector<vector<impalib_type>> &eq2oric,
+                                  const vector<vector<impalib_type>> &reward_proj);  ///< calculate messages from project equality constraint to ORIC
 
-    EqualityConstraintKcMwm(int N_DEPARTMENTS, int N_TEAMS, int N_PROJECTS); ///< constructor
+    EqualityConstraintKcMwm(int N_DEPARTMENTS, int N_TEAMS, int N_PROJECTS);  ///< constructor
 };
 
 /**
@@ -37,82 +37,61 @@ public:
  * @param[out] numDepartments_: N_DEPARTMENTS
  */
 
-EqualityConstraintKcMwm::EqualityConstraintKcMwm(int N_DEPARTMENTS, int N_TEAMS, int N_PROJECTS)
-    : numProjects_(N_PROJECTS), numTeams_(N_TEAMS), numDepartments_(N_DEPARTMENTS){
-                                                    };
+EqualityConstraintKcMwm::EqualityConstraintKcMwm(int N_DEPARTMENTS, int N_TEAMS, int N_PROJECTS) : numProjects_(N_PROJECTS), numTeams_(N_TEAMS), numDepartments_(N_DEPARTMENTS){};
 
 /**
  * Calculate messages from team equality constraint to ORIC for the Knapsack-MWM problem
  *
- * @param[in] rExtrinsicOutputDepartment: messages from departments to teams
+ * @param[in] extrinsic: messages from departments to teams
  * @param[out] rTeam2OricM: messages from team equality constraint to ORIC
- * @param[in] rewardTeam: rewards of teams
+ * @param[in] reward_team: rewards of teams
  */
 
-vector<impalib_type> EqualityConstraintKcMwm::team_eq_constraint_to_oric_update(
-    const vector<vector<impalib_type>> &rExtrinsicOutputDepartment,
-    const vector<impalib_type> &rewardTeam)
-{
+vector<impalib_type> EqualityConstraintKcMwm::team_messages_to_oric(const vector<vector<impalib_type>> &extrinsic, const vector<impalib_type> &reward_team) {
     vector<impalib_type> team2oric(numTeams_, 0);
 
-    for (int i = 0; i < rExtrinsicOutputDepartment.size(); i++)
-    {
-        transform(rExtrinsicOutputDepartment[i].begin(),
-                  rExtrinsicOutputDepartment[i].end(), team2oric.begin(),
-                  team2oric.begin(), std::plus<impalib_type>());
+    for (int i = 0; i < extrinsic.size(); i++) {
+        transform(extrinsic[i].begin(), extrinsic[i].end(), team2oric.begin(), team2oric.begin(), std::plus<impalib_type>());
     }
-    transform(team2oric.begin(), team2oric.end(), rewardTeam.begin(),
-              team2oric.begin(), std::plus<impalib_type>());
+    transform(team2oric.begin(), team2oric.end(), reward_team.begin(), team2oric.begin(), std::plus<impalib_type>());
     return team2oric;
 }
 
 /**
  * Calculate messages from project equality constraint to ORIC for the Knapsack-MWM problem
  *
- * @param[in] rProject2EqConstraintM: messages from projects inequality constraints to project equality constraint
- * @param[out] rEqConstraint2OricM: messages from project equality constraints to ORIC
- * @param[in] rewardProject: rewards of teams-projects combinations
+ * @param[in] proj2eq: messages from projects inequality constraints to project equality constraint
+ * @param[out] eq2oric: messages from project equality constraints to ORIC
+ * @param[in] reward_proj: rewards of teams-projects combinations
  */
 
-void EqualityConstraintKcMwm::project_eq_constraint_to_oric_update(const vector<vector<impalib_type>> &rProject2EqConstraintM,
-                                                                   vector<vector<impalib_type>> &rEqConstraint2OricM,
-                                                                   const vector<vector<impalib_type>> &rewardProject)
-{
-    for (int i = 0; i < rProject2EqConstraintM.size(); i++)
-    {
-        transform(rProject2EqConstraintM[i].begin(), rProject2EqConstraintM[i].end(),
-                  rewardProject[i].begin(), rEqConstraint2OricM[i].begin(),
-                  std::plus<impalib_type>());
+void EqualityConstraintKcMwm::project_messages_to_oric(const vector<vector<impalib_type>> &proj2eq, vector<vector<impalib_type>> &eq2oric, const vector<vector<impalib_type>> &reward_proj) {
+    for (int i = 0; i < proj2eq.size(); i++) {
+        transform(proj2eq[i].begin(), proj2eq[i].end(), reward_proj[i].begin(), eq2oric[i].begin(), std::plus<impalib_type>());
     }
 }
 
 /**
  * Represents a class for the equality constraint for the TSP
  */
-class EqualityConstraintTsp
-{
-private:
-    int          numNodes_; ///< number of nodes
-    int          numEdgeVariables_; ///< number of edge connections
-    bool         filteringFlag_; ///< filtering flag
-    impalib_type alpha_; ///< filtering parameter
+class EqualityConstraintTsp {
+   private:
+    int numNodes_;          ///< number of nodes
+    int numEdgeVariables_;  ///< number of edge connections
+    bool filteringFlag_;    ///< filtering flag
+    impalib_type alpha_;    ///< filtering parameter
 
-public:
-    void edge_ec_to_degree_constraint_relaxed_graph_update(vector<vector<int>> &, vector<vector<impalib_type>> &,
-                                                           vector<vector<impalib_type>> &,
-                                                           vector<vector<impalib_type>> &); ///< calculate messages from edge to degree constraints for relaxed TSP
-    vector<vector<impalib_type>> flip_matrix(vector<vector<impalib_type>> &, vector<vector<int>> &); ///< flip matrix
-    vector<vector<impalib_type>> edge_ec_to_subtour_constraints_update(vector<vector<int>> &, vector<impalib_type> &,
-                                                                       vector<vector<impalib_type>> &,
-                                                                       vector<vector<impalib_type>> &,
-                                                                       vector<vector<int>> &); ///< calculate message from edge to subtour constraint
-    void                         edge_ec_to_degree_constraint_augmented_graph_update(vector<vector<impalib_type>> &,
-                                                                                     vector<vector<impalib_type>> &, vector<vector<int>> &,
-                                                                                     vector<vector<impalib_type>> &,
-                                                                                     vector<vector<impalib_type>> &); ///< calculate messages from edge to degree constraints for augmented TSP
+   public:
+    void messages_to_degree_relaxed(vector<vector<int>> &edges, vector<vector<impalib_type>> &cost_edges, vector<vector<impalib_type>> &deg2eq,
+                                    vector<vector<impalib_type>> &edge2deg);                          ///< calculate messages from edge to degree constraints for relaxed TSP
+    vector<vector<impalib_type>> flip_matrix(vector<vector<impalib_type>> &, vector<vector<int>> &);  ///< flip matrix
+    vector<vector<impalib_type>> messages_to_subtour(vector<vector<int>> &deltaS, vector<impalib_type> &edge_costs, vector<vector<impalib_type>> &deg2edge, vector<vector<impalib_type>> &subtour2edge,
+                                                     vector<vector<int>> &edges);  ///< calculate message from edge to subtour constraint
+    void messages_to_degree_augmented(vector<vector<impalib_type>> &deg2eq, vector<vector<impalib_type>> &subtour2edge, vector<vector<int>> &edges, vector<vector<impalib_type>> &edge_costs,
+                                      vector<vector<impalib_type>> &edge2deg);  ///< calculate messages from edge to degree constraints for augmented TSP
 
     EqualityConstraintTsp(const int NUM_NODES, const int NUM_EDGE_VARIABLES, const bool FILTERING_FLAG,
-                          const impalib_type ALPHA); ///< constructor
+                          const impalib_type ALPHA);  ///< constructor
 };
 
 /**
@@ -128,177 +107,126 @@ public:
  * @param[out] numEdgeVariables_: NUM_EDGE_VARIABLES
  */
 
-EqualityConstraintTsp::EqualityConstraintTsp(const int NUM_NODES, const int NUM_EDGE_VARIABLES,
-                                             const bool FILTERING_FLAG, const impalib_type ALPHA)
-    : filteringFlag_(FILTERING_FLAG), alpha_(ALPHA), numNodes_(NUM_NODES),
-      numEdgeVariables_(NUM_EDGE_VARIABLES){
-      };
+EqualityConstraintTsp::EqualityConstraintTsp(const int NUM_NODES, const int NUM_EDGE_VARIABLES, const bool FILTERING_FLAG, const impalib_type ALPHA)
+    : filteringFlag_(FILTERING_FLAG), alpha_(ALPHA), numNodes_(NUM_NODES), numEdgeVariables_(NUM_EDGE_VARIABLES){};
 
 /**
  * Calculate messages from edge equality constraints to degree constraints for the relaxed TSP
  *
- * @param[in] rEdgeConnections: list of connections for each edge equality constraint
- * @param[in] rEdgeDegreeConstraintCost: cost matrix of edges that has size function of number of edges and number of nodes
- * @param[in] rDegreeConstraint2EqConstraintM: messages from degree constraints to equality constraints
- * @param[out] rEdgeEc2DegreeConstraintM: messages from edge equality constraints to degree constraints
- * 
+ * @param[in] edges: list of connections for each edge equality constraint
+ * @param[in] cost_edges: cost matrix of edges that has size function of number of edges and number of nodes
+ * @param[in] deg2eq: messages from degree constraints to equality constraints
+ * @param[out] edge2deg: messages from edge equality constraints to degree constraints
+ *
  */
 
-void EqualityConstraintTsp::edge_ec_to_degree_constraint_relaxed_graph_update(
-    vector<vector<int>> &rEdgeConnections, vector<vector<impalib_type>> &rEdgeDegreeConstraintCost,
-    vector<vector<impalib_type>> &rDegreeConstraint2EqConstraintM,
-    vector<vector<impalib_type>> &rEdgeEc2DegreeConstraintM)
-{
+void EqualityConstraintTsp::messages_to_degree_relaxed(vector<vector<int>> &edges, vector<vector<impalib_type>> &cost_edges, vector<vector<impalib_type>> &deg2eq,
+                                                       vector<vector<impalib_type>> &edge2deg) {
+    auto reversed = flip_matrix(deg2eq, edges);
 
-    auto reversed = flip_matrix(rDegreeConstraint2EqConstraintM, rEdgeConnections);
-
-    for (int i = 0; i < numEdgeVariables_; i++)
-    {
-        transform(reversed[i].begin(),
-                  reversed[i].end(),
-                  rEdgeDegreeConstraintCost[i].begin(),
-                  rEdgeEc2DegreeConstraintM[i].begin(), plus<impalib_type>());
+    for (int i = 0; i < numEdgeVariables_; i++) {
+        transform(reversed[i].begin(), reversed[i].end(), cost_edges[i].begin(), edge2deg[i].begin(), plus<impalib_type>());
     }
 }
-
 
 /**
  * Calculate messages from edge equality constraints to subtour elimination constraints for the TSP
  *
- * @param[in] rDeltaSIndicesList: list of edge indices forming the subtour elimination constraints
- * @param[in] rCostEdgeVaribale: costs of each edge variable
- * @param[in] rDegreeConstraint2EqConstraintM: messages from degree constraint to equality constraint
- * @param[in] rSubtourConstraints2EdgeEcM: messages from subtour constraints to edge equality constraints
- * @param[in] rEdgeConnections: list of connections for each edge equality constraint
+ * @param[in] deltaS: list of edge indices forming the subtour elimination constraints
+ * @param[in] edge_costs: costs of each edge variable
+ * @param[in] deg2edge: messages from degree constraint to equality constraint
+ * @param[in] subtour2edge: messages from subtour constraints to edge equality constraints
+ * @param[in] edges: list of connections for each edge equality constraint
  * @return edge_ec_to_subtour_constraints_list: messages from edge equality constraint to subtour elimination constraints
- * 
+ *
  */
 
-vector<vector<impalib_type>> EqualityConstraintTsp::edge_ec_to_subtour_constraints_update(
-    vector<vector<int>> &rDeltaSIndicesList, vector<impalib_type> &rCostEdgeVaribale,
-    vector<vector<impalib_type>> &rDegreeConstraint2EqConstraintM,
-    vector<vector<impalib_type>> &rSubtourConstraints2EdgeEcM, vector<vector<int>> &rEdgeConnections)
-{
+vector<vector<impalib_type>> EqualityConstraintTsp::messages_to_subtour(vector<vector<int>> &deltaS, vector<impalib_type> &edge_costs, vector<vector<impalib_type>> &deg2edge,
+                                                                        vector<vector<impalib_type>> &subtour2edge, vector<vector<int>> &edges) {
+    vector<vector<impalib_type>> edge2subtour_list;
 
-    vector<vector<impalib_type>> edge_ec_to_subtour_constraints_list;
+    if (deltaS.size() == 1) {
+        vector<impalib_type> edge2subtour(numEdgeVariables_, zero_value);
 
-    if (rDeltaSIndicesList.size() == 1)
-    {
-        vector<impalib_type> edge_ec_to_subtour_constraints_m(numEdgeVariables_, zero_value);
-
-        vector<impalib_type> combined_degree_constraint_to_eq_constraint_m(numEdgeVariables_, zero_value);
-        for (size_t i = 0; i < numEdgeVariables_; ++i)
-        {
-            combined_degree_constraint_to_eq_constraint_m[i] =
-                rDegreeConstraint2EqConstraintM[i][rEdgeConnections[i][0]]
-                + rDegreeConstraint2EqConstraintM[i][rEdgeConnections[i][1]];
+        vector<impalib_type> deg2eq_sum(numEdgeVariables_, zero_value);
+        for (size_t i = 0; i < numEdgeVariables_; ++i) {
+            deg2eq_sum[i] = deg2edge[i][edges[i][0]] + deg2edge[i][edges[i][1]];
         }
 
-        for (size_t i = 0; i < rDeltaSIndicesList[0].size(); i++)
-        {
-            edge_ec_to_subtour_constraints_m[rDeltaSIndicesList[0][i]] =
-                combined_degree_constraint_to_eq_constraint_m[rDeltaSIndicesList[0][i]]
-                + rCostEdgeVaribale[rDeltaSIndicesList[0][i]];
+        for (size_t i = 0; i < deltaS[0].size(); i++) {
+            edge2subtour[deltaS[0][i]] = deg2eq_sum[deltaS[0][i]] + edge_costs[deltaS[0][i]];
         }
-        edge_ec_to_subtour_constraints_list.push_back(edge_ec_to_subtour_constraints_m);
+        edge2subtour_list.push_back(edge2subtour);
     }
-    
-    else
-    {
-        vector<impalib_type> combined_subtour_constraints_to_edge_ec_m(numEdgeVariables_, zero_value);
-        for (const auto &row : rSubtourConstraints2EdgeEcM)
-        {
-            transform(combined_subtour_constraints_to_edge_ec_m.begin(),
-                      combined_subtour_constraints_to_edge_ec_m.end(), row.begin(),
-                      combined_subtour_constraints_to_edge_ec_m.begin(), std::plus<impalib_type>());
+
+    else {
+        vector<impalib_type> subtour2edge_sum(numEdgeVariables_, zero_value);
+        for (const auto &row : subtour2edge) {
+            transform(subtour2edge_sum.begin(), subtour2edge_sum.end(), row.begin(), subtour2edge_sum.begin(), std::plus<impalib_type>());
         }
 
-        vector<impalib_type> combined_degree_constraint_to_eq_constraint_m(numEdgeVariables_, zero_value);
-        for (size_t i = 0; i < numEdgeVariables_; ++i)
-        {
-            combined_degree_constraint_to_eq_constraint_m[i] =
-                rDegreeConstraint2EqConstraintM[i][rEdgeConnections[i][0]]
-                + rDegreeConstraint2EqConstraintM[i][rEdgeConnections[i][1]];
+        vector<impalib_type> deg2eq_sum(numEdgeVariables_, zero_value);
+        for (size_t i = 0; i < numEdgeVariables_; ++i) {
+            deg2eq_sum[i] = deg2edge[i][edges[i][0]] + deg2edge[i][edges[i][1]];
         }
 
-        for (size_t i = 0; i < rDeltaSIndicesList.size(); i++)
-        {
-            vector<impalib_type> edge_ec_to_subtour_constraints_m(numEdgeVariables_, zero_value);
+        for (size_t i = 0; i < deltaS.size(); i++) {
+            vector<impalib_type> edge2subtour(numEdgeVariables_, zero_value);
 
-            for (size_t j = 0; j < rDeltaSIndicesList[i].size(); j++)
-            {
-                edge_ec_to_subtour_constraints_m[rDeltaSIndicesList[i][j]] =
-                    combined_subtour_constraints_to_edge_ec_m[rDeltaSIndicesList[i][j]]
-                    + combined_degree_constraint_to_eq_constraint_m[rDeltaSIndicesList[i][j]]
-                    + rCostEdgeVaribale[rDeltaSIndicesList[i][j]]
-                    - rSubtourConstraints2EdgeEcM[i]
-                                                 [rDeltaSIndicesList[i][j]];
+            for (size_t j = 0; j < deltaS[i].size(); j++) {
+                edge2subtour[deltaS[i][j]] = subtour2edge_sum[deltaS[i][j]] + deg2eq_sum[deltaS[i][j]] + edge_costs[deltaS[i][j]] - subtour2edge[i][deltaS[i][j]];
             }
-            edge_ec_to_subtour_constraints_list.push_back(edge_ec_to_subtour_constraints_m);
+            edge2subtour_list.push_back(edge2subtour);
         }
     }
-    return edge_ec_to_subtour_constraints_list;
+    return edge2subtour_list;
 }
 
 /**
  * Calculate messages from edge equality constraints to degree constraints for the augmented TSP
  *
- * @param[in] rDegreeConstraint2EqConstraintM: messages from degree constraints to equality constraints
- * @param[in] rSubtourConstraints2EdgeEcM: messages from subtour elimination constraints to edge equality constraints
- * @param[in] rEdgeConnections: list of connections for each edge equality constraint
- * @param[in] rEdgeDegreeConstraintCost: cost matrix of edges that has size function of number of edges and number of nodes
- * @param[out] rEdgeEc2DegreeConstraintM: messages from edge equality constraints to degree constraints
- * 
+ * @param[in] deg2eq: messages from degree constraints to equality constraints
+ * @param[in] subtour2edge: messages from subtour elimination constraints to edge equality constraints
+ * @param[in] edges: list of connections for each edge equality constraint
+ * @param[in] edge_costs: cost matrix of edges that has size function of number of edges and number of nodes
+ * @param[out] edge2deg: messages from edge equality constraints to degree constraints
+ *
  */
 
-void EqualityConstraintTsp::edge_ec_to_degree_constraint_augmented_graph_update(
-    vector<vector<impalib_type>> &rDegreeConstraint2EqConstraintM,
-    vector<vector<impalib_type>> &rSubtourConstraints2EdgeEcM, vector<vector<int>> &rEdgeConnections,
-    vector<vector<impalib_type>> &rEdgeDegreeConstraintCost, vector<vector<impalib_type>> &rEdgeEc2DegreeConstraintM)
-{
-
-    vector<impalib_type> combined_subtour_constraints_to_edge_ec_m(numEdgeVariables_, zero_value);
-    for (const auto &row : rSubtourConstraints2EdgeEcM)
-    {
-        transform(combined_subtour_constraints_to_edge_ec_m.begin(), combined_subtour_constraints_to_edge_ec_m.end(),
-                  row.begin(), combined_subtour_constraints_to_edge_ec_m.begin(), std::plus<impalib_type>());
+void EqualityConstraintTsp::messages_to_degree_augmented(vector<vector<impalib_type>> &deg2eq, vector<vector<impalib_type>> &subtour2edge, vector<vector<int>> &edges,
+                                                         vector<vector<impalib_type>> &edge_costs, vector<vector<impalib_type>> &edge2deg) {
+    vector<impalib_type> subtour2edge_sum(numEdgeVariables_, zero_value);
+    for (const auto &row : subtour2edge) {
+        transform(subtour2edge_sum.begin(), subtour2edge_sum.end(), row.begin(), subtour2edge_sum.begin(), std::plus<impalib_type>());
     }
 
-    for (size_t i = 0; i < rEdgeConnections.size(); i++)
-    {
-
+    for (size_t i = 0; i < edges.size(); i++) {
         // Update the message for the first node of the edge
-        const auto first_node = rEdgeConnections[i][0];
-        const auto second_node = rEdgeConnections[i][1];
-        rEdgeEc2DegreeConstraintM[i][first_node] =
-            combined_subtour_constraints_to_edge_ec_m[i] + rDegreeConstraint2EqConstraintM[i][second_node]
-            + rEdgeDegreeConstraintCost[i][first_node];
+        const auto first_node = edges[i][0];
+        const auto second_node = edges[i][1];
+        edge2deg[i][first_node] = subtour2edge_sum[i] + deg2eq[i][second_node] + edge_costs[i][first_node];
 
         // Update the message for the second node of the edge
-        rEdgeEc2DegreeConstraintM[i][second_node] =
-            combined_subtour_constraints_to_edge_ec_m[i] + rDegreeConstraint2EqConstraintM[i][first_node]
-            + rEdgeDegreeConstraintCost[i][second_node];
+        edge2deg[i][second_node] = subtour2edge_sum[i] + deg2eq[i][first_node] + edge_costs[i][second_node];
     }
 }
 
 /**
  * Flip a matrix to facilitate message updates for the TSP. Matrices will be in the same format during IMPA
  *
- * @param[in] rMatrix: matrix that requires flipping
- * @param[in] rEdgeConnections: list of connections for each edge equality constraint
+ * @param[in] M: matrix that requires flipping
+ * @param[in] edges: list of connections for each edge equality constraint
  * @param[out] rFlippedMatrix: flipped matrix
- * 
+ *
  */
 
-vector<vector<impalib_type>> EqualityConstraintTsp::flip_matrix(vector<vector<impalib_type>> &rMatrix, vector<vector<int>> &rEdgeConnections)
-{
-    auto flipped = rMatrix;
-    for (size_t l = 0; l < rEdgeConnections.size(); ++l)
-    {
-        int row                = rEdgeConnections[l][0];
-        int col                = rEdgeConnections[l][1];
-        flipped[l][row] = rMatrix[l][col];
-        flipped[l][col] = rMatrix[l][row];
+vector<vector<impalib_type>> EqualityConstraintTsp::flip_matrix(vector<vector<impalib_type>> &M, vector<vector<int>> &edges) {
+    auto flipped = M;
+    for (size_t l = 0; l < edges.size(); ++l) {
+        int row = edges[l][0];
+        int col = edges[l][1];
+        flipped[l][row] = M[l][col];
+        flipped[l][col] = M[l][row];
     }
     return flipped;
 }

--- a/include/impalib/update_equality_constraint.hpp
+++ b/include/impalib/update_equality_constraint.hpp
@@ -82,12 +82,12 @@ class EqualityConstraintTsp {
     impalib_type alpha_;    ///< filtering parameter
 
    public:
-    void messages_to_degree_relaxed(vector<vector<int>> &edges, vector<vector<impalib_type>> &cost_edges, vector<vector<impalib_type>> &deg2eq,
+    void messages_to_degree_relaxed(const vector<vector<int>> &edges, const vector<vector<impalib_type>> &cost_edges, const vector<vector<impalib_type>> &deg2eq,
                                     vector<vector<impalib_type>> &edge2deg);                          ///< calculate messages from edge to degree constraints for relaxed TSP
-    vector<vector<impalib_type>> flip_matrix(vector<vector<impalib_type>> &, vector<vector<int>> &);  ///< flip matrix
-    vector<vector<impalib_type>> messages_to_subtour(vector<vector<int>> &deltaS, vector<impalib_type> &edge_costs, vector<vector<impalib_type>> &deg2edge, vector<vector<impalib_type>> &subtour2edge,
-                                                     vector<vector<int>> &edges);  ///< calculate message from edge to subtour constraint
-    void messages_to_degree_augmented(vector<vector<impalib_type>> &deg2eq, vector<vector<impalib_type>> &subtour2edge, vector<vector<int>> &edges, vector<vector<impalib_type>> &edge_costs,
+    vector<vector<impalib_type>> flip_matrix(const vector<vector<impalib_type>> &, const vector<vector<int>> &);  ///< flip matrix
+    vector<vector<impalib_type>> messages_to_subtour(const vector<vector<int>> &deltaS, const vector<impalib_type> &edge_costs, const vector<vector<impalib_type>> &deg2edge, const vector<vector<impalib_type>> &subtour2edge,
+                                                     const vector<vector<int>> &edges);  ///< calculate message from edge to subtour constraint
+    void messages_to_degree_augmented(const vector<vector<impalib_type>> &deg2eq, const vector<vector<impalib_type>> &subtour2edge, const vector<vector<int>> &edges, const vector<vector<impalib_type>> &edge_costs,
                                       vector<vector<impalib_type>> &edge2deg);  ///< calculate messages from edge to degree constraints for augmented TSP
 
     EqualityConstraintTsp(const int NUM_NODES, const int NUM_EDGE_VARIABLES, const bool FILTERING_FLAG,
@@ -120,7 +120,7 @@ EqualityConstraintTsp::EqualityConstraintTsp(const int NUM_NODES, const int NUM_
  *
  */
 
-void EqualityConstraintTsp::messages_to_degree_relaxed(vector<vector<int>> &edges, vector<vector<impalib_type>> &cost_edges, vector<vector<impalib_type>> &deg2eq,
+void EqualityConstraintTsp::messages_to_degree_relaxed(const vector<vector<int>> &edges, const vector<vector<impalib_type>> &cost_edges, const vector<vector<impalib_type>> &deg2eq,
                                                        vector<vector<impalib_type>> &edge2deg) {
     auto reversed = flip_matrix(deg2eq, edges);
 
@@ -141,8 +141,8 @@ void EqualityConstraintTsp::messages_to_degree_relaxed(vector<vector<int>> &edge
  *
  */
 
-vector<vector<impalib_type>> EqualityConstraintTsp::messages_to_subtour(vector<vector<int>> &deltaS, vector<impalib_type> &edge_costs, vector<vector<impalib_type>> &deg2edge,
-                                                                        vector<vector<impalib_type>> &subtour2edge, vector<vector<int>> &edges) {
+vector<vector<impalib_type>> EqualityConstraintTsp::messages_to_subtour(const vector<vector<int>> &deltaS, const vector<impalib_type> &edge_costs, const vector<vector<impalib_type>> &deg2edge,
+                                                                        const vector<vector<impalib_type>> &subtour2edge, const vector<vector<int>> &edges) {
     vector<vector<impalib_type>> edge2subtour_list;
 
     if (deltaS.size() == 1) {
@@ -193,8 +193,8 @@ vector<vector<impalib_type>> EqualityConstraintTsp::messages_to_subtour(vector<v
  *
  */
 
-void EqualityConstraintTsp::messages_to_degree_augmented(vector<vector<impalib_type>> &deg2eq, vector<vector<impalib_type>> &subtour2edge, vector<vector<int>> &edges,
-                                                         vector<vector<impalib_type>> &edge_costs, vector<vector<impalib_type>> &edge2deg) {
+void EqualityConstraintTsp::messages_to_degree_augmented(const vector<vector<impalib_type>> &deg2eq, const vector<vector<impalib_type>> &subtour2edge, const vector<vector<int>> &edges,
+                                                         const vector<vector<impalib_type>> &edge_costs, vector<vector<impalib_type>> &edge2deg) {
     vector<impalib_type> subtour2edge_sum(numEdgeVariables_, zero_value);
     for (const auto &row : subtour2edge) {
         transform(subtour2edge_sum.begin(), subtour2edge_sum.end(), row.begin(), subtour2edge_sum.begin(), std::plus<impalib_type>());
@@ -220,7 +220,7 @@ void EqualityConstraintTsp::messages_to_degree_augmented(vector<vector<impalib_t
  *
  */
 
-vector<vector<impalib_type>> EqualityConstraintTsp::flip_matrix(vector<vector<impalib_type>> &M, vector<vector<int>> &edges) {
+vector<vector<impalib_type>> EqualityConstraintTsp::flip_matrix(const vector<vector<impalib_type>> &M, const vector<vector<int>> &edges) {
     auto flipped = M;
     for (size_t l = 0; l < edges.size(); ++l) {
         int row = edges[l][0];

--- a/include/impalib/update_equality_constraint.hpp
+++ b/include/impalib/update_equality_constraint.hpp
@@ -32,22 +32,17 @@ class EqualityConstraintKcMwm {
  * @param[in] N_DEPARTMENTS: number of departments
  * @param[in] N_TEAMS: number of teams
  * @param[in] N_PROJECTS: number of projects
- * @param[out] numProjects_: N_PROJECTS
- * @param[out] numTeams_: N_TEAMS
- * @param[out] numDepartments_: N_DEPARTMENTS
  */
-
-EqualityConstraintKcMwm::EqualityConstraintKcMwm(int N_DEPARTMENTS, int N_TEAMS, int N_PROJECTS) : numProjects_(N_PROJECTS), numTeams_(N_TEAMS), numDepartments_(N_DEPARTMENTS){};
+inline EqualityConstraintKcMwm::EqualityConstraintKcMwm(int N_DEPARTMENTS, int N_TEAMS, int N_PROJECTS) : numProjects_(N_PROJECTS), numTeams_(N_TEAMS), numDepartments_(N_DEPARTMENTS){};
 
 /**
  * Calculate messages from team equality constraint to ORIC for the Knapsack-MWM problem
  *
  * @param[in] extrinsic: messages from departments to teams
- * @param[out] rTeam2OricM: messages from team equality constraint to ORIC
  * @param[in] reward_team: rewards of teams
+ * @returns: messages from team equality constraint to ORIC
  */
-
-vector<impalib_type> EqualityConstraintKcMwm::team_messages_to_oric(const vector<vector<impalib_type>> &extrinsic, const vector<impalib_type> &reward_team) {
+inline vector<impalib_type> EqualityConstraintKcMwm::team_messages_to_oric(const vector<vector<impalib_type>> &extrinsic, const vector<impalib_type> &reward_team) {
     vector<impalib_type> team2oric(numTeams_, 0);
 
     for (int i = 0; i < extrinsic.size(); i++) {
@@ -61,11 +56,10 @@ vector<impalib_type> EqualityConstraintKcMwm::team_messages_to_oric(const vector
  * Calculate messages from project equality constraint to ORIC for the Knapsack-MWM problem
  *
  * @param[in] proj2eq: messages from projects inequality constraints to project equality constraint
- * @param[out] eq2oric: messages from project equality constraints to ORIC
  * @param[in] reward_proj: rewards of teams-projects combinations
+ * @returns: messages from project equality constraints to ORIC
  */
-
-vector<vector<impalib_type>> EqualityConstraintKcMwm::project_messages_to_oric(const vector<vector<impalib_type>> &proj2eq, const vector<vector<impalib_type>> &reward_proj) {
+inline vector<vector<impalib_type>> EqualityConstraintKcMwm::project_messages_to_oric(const vector<vector<impalib_type>> &proj2eq, const vector<vector<impalib_type>> &reward_proj) {
     vector<vector<impalib_type>> eq2oric(proj2eq.size());
     for (int i = 0; i < proj2eq.size(); i++) {
         transform(proj2eq[i].begin(), proj2eq[i].end(), reward_proj[i].begin(), eq2oric[i].begin(), std::plus<impalib_type>());
@@ -103,13 +97,8 @@ class EqualityConstraintTsp {
  * @param[in] NUM_EDGE_VARIABLES: number of connections between nodes
  * @param[in] FILTERING_FLAG: filtering on or off
  * @param[in] ALPHA: filtering parameter value (between 0 and 1)
- * @param[out] filteringFlag_: FILTERING_FLAG
- * @param[out] alpha_: ALPHA
- * @param[out] numNodes_: NUM_NODES
- * @param[out] numEdgeVariables_: NUM_EDGE_VARIABLES
  */
-
-EqualityConstraintTsp::EqualityConstraintTsp(const int NUM_NODES, const int NUM_EDGE_VARIABLES, const bool FILTERING_FLAG, const impalib_type ALPHA)
+inline EqualityConstraintTsp::EqualityConstraintTsp(const int NUM_NODES, const int NUM_EDGE_VARIABLES, const bool FILTERING_FLAG, const impalib_type ALPHA)
     : filteringFlag_(FILTERING_FLAG), alpha_(ALPHA), numNodes_(NUM_NODES), numEdgeVariables_(NUM_EDGE_VARIABLES){};
 
 /**
@@ -118,11 +107,9 @@ EqualityConstraintTsp::EqualityConstraintTsp(const int NUM_NODES, const int NUM_
  * @param[in] edges: list of connections for each edge equality constraint
  * @param[in] cost_edges: cost matrix of edges that has size function of number of edges and number of nodes
  * @param[in] deg2eq: messages from degree constraints to equality constraints
- * @param[out] edge2deg: messages from edge equality constraints to degree constraints
  *
  */
-
-void EqualityConstraintTsp::messages_to_degree_relaxed(const vector<vector<int>> &edges, const vector<vector<impalib_type>> &cost_edges, const vector<vector<impalib_type>> &deg2eq,
+inline void EqualityConstraintTsp::messages_to_degree_relaxed(const vector<vector<int>> &edges, const vector<vector<impalib_type>> &cost_edges, const vector<vector<impalib_type>> &deg2eq,
                                                        vector<vector<impalib_type>> &edge2deg) {
     auto reversed = flip_matrix(deg2eq, edges);
 
@@ -139,11 +126,10 @@ void EqualityConstraintTsp::messages_to_degree_relaxed(const vector<vector<int>>
  * @param[in] deg2edge: messages from degree constraint to equality constraint
  * @param[in] subtour2edge: messages from subtour constraints to edge equality constraints
  * @param[in] edges: list of connections for each edge equality constraint
- * @return edge_ec_to_subtour_constraints_list: messages from edge equality constraint to subtour elimination constraints
+ * @returns: messages from edge equality constraint to subtour elimination constraints
  *
  */
-
-vector<vector<impalib_type>> EqualityConstraintTsp::messages_to_subtour(const vector<vector<int>> &deltaS, const vector<impalib_type> &edge_costs, const vector<vector<impalib_type>> &deg2edge,
+inline vector<vector<impalib_type>> EqualityConstraintTsp::messages_to_subtour(const vector<vector<int>> &deltaS, const vector<impalib_type> &edge_costs, const vector<vector<impalib_type>> &deg2edge,
                                                                         const vector<vector<impalib_type>> &subtour2edge, const vector<vector<int>> &edges) {
     vector<vector<impalib_type>> edge2subtour_list;
 
@@ -194,8 +180,7 @@ vector<vector<impalib_type>> EqualityConstraintTsp::messages_to_subtour(const ve
  * @param[out] edge2deg: messages from edge equality constraints to degree constraints
  *
  */
-
-void EqualityConstraintTsp::messages_to_degree_augmented(const vector<vector<impalib_type>> &deg2eq, const vector<vector<impalib_type>> &subtour2edge, const vector<vector<int>> &edges,
+inline void EqualityConstraintTsp::messages_to_degree_augmented(const vector<vector<impalib_type>> &deg2eq, const vector<vector<impalib_type>> &subtour2edge, const vector<vector<int>> &edges,
                                                          const vector<vector<impalib_type>> &edge_costs, vector<vector<impalib_type>> &edge2deg) {
     vector<impalib_type> subtour2edge_sum(numEdgeVariables_, zero_value);
     for (const auto &row : subtour2edge) {
@@ -218,11 +203,10 @@ void EqualityConstraintTsp::messages_to_degree_augmented(const vector<vector<imp
  *
  * @param[in] M: matrix that requires flipping
  * @param[in] edges: list of connections for each edge equality constraint
- * @param[out] rFlippedMatrix: flipped matrix
+ * @param[out]: flipped matrix
  *
  */
-
-vector<vector<impalib_type>> EqualityConstraintTsp::flip_matrix(const vector<vector<impalib_type>> &M, const vector<vector<int>> &edges) {
+inline vector<vector<impalib_type>> EqualityConstraintTsp::flip_matrix(const vector<vector<impalib_type>> &M, const vector<vector<int>> &edges) {
     auto flipped = M;
     for (size_t l = 0; l < edges.size(); ++l) {
         int row = edges[l][0];

--- a/include/impalib/update_equality_constraint.hpp
+++ b/include/impalib/update_equality_constraint.hpp
@@ -54,18 +54,14 @@ void EqualityConstraintKcMwm::team_eq_constraint_to_oric_update(
     vector<vector<impalib_type>> &rExtrinsicOutputDepartment, vector<impalib_type> &rTeam2OricM,
     vector<impalib_type> &rewardTeam)
 {
-    // Vector to store intermediate values for team to ORIC messages
     vector<impalib_type> intermediate_team_to_oric_m(numTeams_, 0);
 
-    // Iterate over each department
     for (int department_index = 0; department_index < rExtrinsicOutputDepartment.size(); department_index++)
     {
-        // Sum rExtrinsicOutputDepartment
         transform(rExtrinsicOutputDepartment[department_index].begin(),
                   rExtrinsicOutputDepartment[department_index].end(), intermediate_team_to_oric_m.begin(),
                   intermediate_team_to_oric_m.begin(), std::plus<impalib_type>());
     }
-    // Calculate rTeam2OricM
     transform(intermediate_team_to_oric_m.begin(), intermediate_team_to_oric_m.end(), rewardTeam.begin(),
               rTeam2OricM.begin(), std::plus<impalib_type>());
 }
@@ -82,10 +78,8 @@ void EqualityConstraintKcMwm::project_eq_constraint_to_oric_update(vector<vector
                                                                    vector<vector<impalib_type>> &rEqConstraint2OricM,
                                                                    vector<vector<impalib_type>> &rewardProject)
 {
-    // Iterate over each project
     for (int project_index = 0; project_index < rProject2EqConstraintM.size(); project_index++)
     {
-        // Transform and sum the messages from project to equality constraints and rewards for each project to get rEqConstraint2OricM
         transform(rProject2EqConstraintM[project_index].begin(), rProject2EqConstraintM[project_index].end(),
                   rewardProject[project_index].begin(), rEqConstraint2OricM[project_index].begin(),
                   std::plus<impalib_type>());
@@ -156,13 +150,9 @@ void EqualityConstraintTsp::edge_ec_to_degree_constraint_relaxed_graph_update(
     vector<vector<impalib_type>> &rEdgeEc2DegreeConstraintM)
 {
 
-    // Create a copy of the messages from degree constraints to equality constraints
     vector<vector<impalib_type>> flipped_degree_constraint_to_eq_constraint_m = rDegreeConstraint2EqConstraintM;
-
-    // Flip the matrix representing the messages from degree constraints to equality constraints
     flip_matrix(rDegreeConstraint2EqConstraintM, rEdgeConnections, flipped_degree_constraint_to_eq_constraint_m);
 
-    // Update the messages from edge equality constraints to degree constraints
     for (int edge_variable_index = 0; edge_variable_index < numEdgeVariables_; edge_variable_index++)
     {
         transform(flipped_degree_constraint_to_eq_constraint_m[edge_variable_index].begin(),
@@ -193,63 +183,50 @@ vector<vector<impalib_type>> EqualityConstraintTsp::edge_ec_to_subtour_constrain
 
     vector<vector<impalib_type>> edge_ec_to_subtour_constraints_list;
 
-    // If there's only one subtour constraint
     if (rDeltaSIndicesList.size() == 1)
     {
-        // Initialize a vector to store the messages from edge equality constraints to subtour constraints
         vector<impalib_type> edge_ec_to_subtour_constraints_m(numEdgeVariables_, zero_value);
 
-        // Initialize a vector to store the combined messages from degree constraints to equality constraints
         vector<impalib_type> combined_degree_constraint_to_eq_constraint_m(numEdgeVariables_, zero_value);
         for (size_t index_edge_variable = 0; index_edge_variable < numEdgeVariables_; ++index_edge_variable)
         {
-            // Combine the messages from degree constraints to equality constraints for each edge variable
             combined_degree_constraint_to_eq_constraint_m[index_edge_variable] =
                 rDegreeConstraint2EqConstraintM[index_edge_variable][rEdgeConnections[index_edge_variable][0]]
                 + rDegreeConstraint2EqConstraintM[index_edge_variable][rEdgeConnections[index_edge_variable][1]];
         }
 
-        // Update the messages from edge equality constraints to subtour constraints
         for (size_t i = 0; i < rDeltaSIndicesList[0].size(); i++)
         {
             edge_ec_to_subtour_constraints_m[rDeltaSIndicesList[0][i]] =
                 combined_degree_constraint_to_eq_constraint_m[rDeltaSIndicesList[0][i]]
                 + rCostEdgeVaribale[rDeltaSIndicesList[0][i]];
         }
-        // Add the updated messages to the list
         edge_ec_to_subtour_constraints_list.push_back(edge_ec_to_subtour_constraints_m);
     }
     
     else
     {
-        // Initialize a vector to store the combined messages from subtour constraints to edge equality constraints
         vector<impalib_type> combined_subtour_constraints_to_edge_ec_m(numEdgeVariables_, zero_value);
         for (const auto &row : rSubtourConstraints2EdgeEcM)
         {
-            // Sum the messages from subtour constraints to edge equality constraints for each edge variable
             transform(combined_subtour_constraints_to_edge_ec_m.begin(),
                       combined_subtour_constraints_to_edge_ec_m.end(), row.begin(),
                       combined_subtour_constraints_to_edge_ec_m.begin(), std::plus<impalib_type>());
         }
 
-        // Initialize a vector to store the combined messages from degree constraints to equality constraints
         vector<impalib_type> combined_degree_constraint_to_eq_constraint_m(numEdgeVariables_, zero_value);
         for (size_t index_edge_variable = 0; index_edge_variable < numEdgeVariables_; ++index_edge_variable)
         {
-            // Combine the messages from degree constraints to equality constraints for each edge variable
             combined_degree_constraint_to_eq_constraint_m[index_edge_variable] =
                 rDegreeConstraint2EqConstraintM[index_edge_variable][rEdgeConnections[index_edge_variable][0]]
                 + rDegreeConstraint2EqConstraintM[index_edge_variable][rEdgeConnections[index_edge_variable][1]];
         }
 
-        // Iterate over each subtour constraint
         for (size_t index_subtour_constraint = 0; index_subtour_constraint < rDeltaSIndicesList.size();
              index_subtour_constraint++)
         {
-            // Initialize a vector to store the messages from edge equality constraints to subtour constraints
             vector<impalib_type> edge_ec_to_subtour_constraints_m(numEdgeVariables_, zero_value);
 
-            // Update the messages from edge equality constraints to subtour constraints
             for (size_t i = 0; i < rDeltaSIndicesList[index_subtour_constraint].size(); i++)
             {
                 edge_ec_to_subtour_constraints_m[rDeltaSIndicesList[index_subtour_constraint][i]] =
@@ -259,11 +236,9 @@ vector<vector<impalib_type>> EqualityConstraintTsp::edge_ec_to_subtour_constrain
                     - rSubtourConstraints2EdgeEcM[index_subtour_constraint]
                                                  [rDeltaSIndicesList[index_subtour_constraint][i]];
             }
-            // Add the updated messages to the list
             edge_ec_to_subtour_constraints_list.push_back(edge_ec_to_subtour_constraints_m);
         }
     }
-    // Return the list of udpated messages from edge equality constraints to subtour constraints
     return edge_ec_to_subtour_constraints_list;
 }
 
@@ -284,16 +259,13 @@ void EqualityConstraintTsp::edge_ec_to_degree_constraint_augmented_graph_update(
     vector<vector<impalib_type>> &rEdgeDegreeConstraintCost, vector<vector<impalib_type>> &rEdgeEc2DegreeConstraintM)
 {
 
-    // Initialize a vector to store the combined messages from subtour constraints to edge equality constraints
     vector<impalib_type> combined_subtour_constraints_to_edge_ec_m(numEdgeVariables_, zero_value);
     for (const auto &row : rSubtourConstraints2EdgeEcM)
     {
-        // Sum the messages from subtour constraints to edge equality constraints for each edge variable
         transform(combined_subtour_constraints_to_edge_ec_m.begin(), combined_subtour_constraints_to_edge_ec_m.end(),
                   row.begin(), combined_subtour_constraints_to_edge_ec_m.begin(), std::plus<impalib_type>());
     }
 
-    // Update the messages from edge equality constraints to degree constraints
     for (size_t i = 0; i < rEdgeConnections.size(); i++)
     {
 

--- a/include/impalib/update_equality_constraint.hpp
+++ b/include/impalib/update_equality_constraint.hpp
@@ -56,10 +56,10 @@ void EqualityConstraintKcMwm::team_eq_constraint_to_oric_update(
 {
     vector<impalib_type> intermediate_team_to_oric_m(numTeams_, 0);
 
-    for (int department_index = 0; department_index < rExtrinsicOutputDepartment.size(); department_index++)
+    for (int i = 0; i < rExtrinsicOutputDepartment.size(); i++)
     {
-        transform(rExtrinsicOutputDepartment[department_index].begin(),
-                  rExtrinsicOutputDepartment[department_index].end(), intermediate_team_to_oric_m.begin(),
+        transform(rExtrinsicOutputDepartment[i].begin(),
+                  rExtrinsicOutputDepartment[i].end(), intermediate_team_to_oric_m.begin(),
                   intermediate_team_to_oric_m.begin(), std::plus<impalib_type>());
     }
     transform(intermediate_team_to_oric_m.begin(), intermediate_team_to_oric_m.end(), rewardTeam.begin(),
@@ -78,10 +78,10 @@ void EqualityConstraintKcMwm::project_eq_constraint_to_oric_update(vector<vector
                                                                    vector<vector<impalib_type>> &rEqConstraint2OricM,
                                                                    vector<vector<impalib_type>> &rewardProject)
 {
-    for (int project_index = 0; project_index < rProject2EqConstraintM.size(); project_index++)
+    for (int i = 0; i < rProject2EqConstraintM.size(); i++)
     {
-        transform(rProject2EqConstraintM[project_index].begin(), rProject2EqConstraintM[project_index].end(),
-                  rewardProject[project_index].begin(), rEqConstraint2OricM[project_index].begin(),
+        transform(rProject2EqConstraintM[i].begin(), rProject2EqConstraintM[i].end(),
+                  rewardProject[i].begin(), rEqConstraint2OricM[i].begin(),
                   std::plus<impalib_type>());
     }
 }
@@ -153,12 +153,12 @@ void EqualityConstraintTsp::edge_ec_to_degree_constraint_relaxed_graph_update(
     vector<vector<impalib_type>> flipped_degree_constraint_to_eq_constraint_m = rDegreeConstraint2EqConstraintM;
     flip_matrix(rDegreeConstraint2EqConstraintM, rEdgeConnections, flipped_degree_constraint_to_eq_constraint_m);
 
-    for (int edge_variable_index = 0; edge_variable_index < numEdgeVariables_; edge_variable_index++)
+    for (int i = 0; i < numEdgeVariables_; i++)
     {
-        transform(flipped_degree_constraint_to_eq_constraint_m[edge_variable_index].begin(),
-                  flipped_degree_constraint_to_eq_constraint_m[edge_variable_index].end(),
-                  rEdgeDegreeConstraintCost[edge_variable_index].begin(),
-                  rEdgeEc2DegreeConstraintM[edge_variable_index].begin(), plus<impalib_type>());
+        transform(flipped_degree_constraint_to_eq_constraint_m[i].begin(),
+                  flipped_degree_constraint_to_eq_constraint_m[i].end(),
+                  rEdgeDegreeConstraintCost[i].begin(),
+                  rEdgeEc2DegreeConstraintM[i].begin(), plus<impalib_type>());
     }
 }
 
@@ -188,11 +188,11 @@ vector<vector<impalib_type>> EqualityConstraintTsp::edge_ec_to_subtour_constrain
         vector<impalib_type> edge_ec_to_subtour_constraints_m(numEdgeVariables_, zero_value);
 
         vector<impalib_type> combined_degree_constraint_to_eq_constraint_m(numEdgeVariables_, zero_value);
-        for (size_t index_edge_variable = 0; index_edge_variable < numEdgeVariables_; ++index_edge_variable)
+        for (size_t i = 0; i < numEdgeVariables_; ++i)
         {
-            combined_degree_constraint_to_eq_constraint_m[index_edge_variable] =
-                rDegreeConstraint2EqConstraintM[index_edge_variable][rEdgeConnections[index_edge_variable][0]]
-                + rDegreeConstraint2EqConstraintM[index_edge_variable][rEdgeConnections[index_edge_variable][1]];
+            combined_degree_constraint_to_eq_constraint_m[i] =
+                rDegreeConstraint2EqConstraintM[i][rEdgeConnections[i][0]]
+                + rDegreeConstraint2EqConstraintM[i][rEdgeConnections[i][1]];
         }
 
         for (size_t i = 0; i < rDeltaSIndicesList[0].size(); i++)
@@ -215,26 +215,25 @@ vector<vector<impalib_type>> EqualityConstraintTsp::edge_ec_to_subtour_constrain
         }
 
         vector<impalib_type> combined_degree_constraint_to_eq_constraint_m(numEdgeVariables_, zero_value);
-        for (size_t index_edge_variable = 0; index_edge_variable < numEdgeVariables_; ++index_edge_variable)
+        for (size_t i = 0; i < numEdgeVariables_; ++i)
         {
-            combined_degree_constraint_to_eq_constraint_m[index_edge_variable] =
-                rDegreeConstraint2EqConstraintM[index_edge_variable][rEdgeConnections[index_edge_variable][0]]
-                + rDegreeConstraint2EqConstraintM[index_edge_variable][rEdgeConnections[index_edge_variable][1]];
+            combined_degree_constraint_to_eq_constraint_m[i] =
+                rDegreeConstraint2EqConstraintM[i][rEdgeConnections[i][0]]
+                + rDegreeConstraint2EqConstraintM[i][rEdgeConnections[i][1]];
         }
 
-        for (size_t index_subtour_constraint = 0; index_subtour_constraint < rDeltaSIndicesList.size();
-             index_subtour_constraint++)
+        for (size_t i = 0; i < rDeltaSIndicesList.size(); i++)
         {
             vector<impalib_type> edge_ec_to_subtour_constraints_m(numEdgeVariables_, zero_value);
 
-            for (size_t i = 0; i < rDeltaSIndicesList[index_subtour_constraint].size(); i++)
+            for (size_t j = 0; j < rDeltaSIndicesList[i].size(); j++)
             {
-                edge_ec_to_subtour_constraints_m[rDeltaSIndicesList[index_subtour_constraint][i]] =
-                    combined_subtour_constraints_to_edge_ec_m[rDeltaSIndicesList[index_subtour_constraint][i]]
-                    + combined_degree_constraint_to_eq_constraint_m[rDeltaSIndicesList[index_subtour_constraint][i]]
-                    + rCostEdgeVaribale[rDeltaSIndicesList[index_subtour_constraint][i]]
-                    - rSubtourConstraints2EdgeEcM[index_subtour_constraint]
-                                                 [rDeltaSIndicesList[index_subtour_constraint][i]];
+                edge_ec_to_subtour_constraints_m[rDeltaSIndicesList[i][j]] =
+                    combined_subtour_constraints_to_edge_ec_m[rDeltaSIndicesList[i][j]]
+                    + combined_degree_constraint_to_eq_constraint_m[rDeltaSIndicesList[i][j]]
+                    + rCostEdgeVaribale[rDeltaSIndicesList[i][j]]
+                    - rSubtourConstraints2EdgeEcM[i]
+                                                 [rDeltaSIndicesList[i][j]];
             }
             edge_ec_to_subtour_constraints_list.push_back(edge_ec_to_subtour_constraints_m);
         }

--- a/include/impalib/update_or_inequality_constraint.hpp
+++ b/include/impalib/update_or_inequality_constraint.hpp
@@ -20,9 +20,9 @@ class OrInequalityConstraint {
 
    public:
     void messages_to_project_eq(const vector<vector<impalib_type>> &eq2oric, const vector<impalib_type> &team2oric, vector<vector<impalib_type>> &oric2eq, vector<vector<impalib_type>> &eq2proj,
-                                const vector<vector<impalib_type>> &reward_project);  ///< update messages from ORIC to project equality constraint
+                                const vector<vector<impalib_type>> &reward_project) const;  ///< update messages from ORIC to project equality constraint
 
-    vector<impalib_type> messages_to_team_eq(const vector<vector<impalib_type>> &eq2oric);  ///< calculate messages from team ORIC to team equality constraint
+    vector<impalib_type> messages_to_team_eq(const vector<vector<impalib_type>> &eq2oric) const;  ///< calculate messages from team ORIC to team equality constraint
 
     OrInequalityConstraint(int N_DEPARTMENTS, int N_TEAMS, int N_PROJECTS);  ///< constructor
 };
@@ -49,7 +49,7 @@ inline OrInequalityConstraint::OrInequalityConstraint(const int N_DEPARTMENTS, c
  *
  */
 inline void OrInequalityConstraint::messages_to_project_eq(const vector<vector<impalib_type>> &eq2oric, const vector<impalib_type> &team2oric, vector<vector<impalib_type>> &oric2eq,
-                                                    vector<vector<impalib_type>> &eq2proj, const vector<vector<impalib_type>> &reward_project) {
+                                                    vector<vector<impalib_type>> &eq2proj, const vector<vector<impalib_type>> &reward_project) const {
     vector<vector<impalib_type>> forward(numProjects_ + 1, vector<impalib_type>(maxStateIc_ + 1, zero_value));
     vector<vector<impalib_type>> backward(numProjects_ + 1, vector<impalib_type>(maxStateIc_ + 1, zero_value));
 
@@ -91,7 +91,7 @@ inline void OrInequalityConstraint::messages_to_project_eq(const vector<vector<i
  * @returns : messages from ORIC to teams
  *
  */
-inline vector<impalib_type> OrInequalityConstraint::messages_to_team_eq(const vector<vector<impalib_type>> &eq2oric) {
+inline vector<impalib_type> OrInequalityConstraint::messages_to_team_eq(const vector<vector<impalib_type>> &eq2oric) const {
     vector<impalib_type> oric2team(numTeams_);
     for (int i = 0; i < oric2team.size(); i++) {
         impalib_type minValue = 1000000;

--- a/include/impalib/update_or_inequality_constraint.hpp
+++ b/include/impalib/update_or_inequality_constraint.hpp
@@ -67,7 +67,7 @@ void OrInequalityConstraint::oric_to_project_eq_constraint_update(vector<vector<
     vector<vector<impalib_type>> stage_backward_messages_ORIC_project(
         numProjects_ + 1, vector<impalib_type>(maxStateIc_ + 1, zero_value));
 
-    for (int team_index = 0; team_index < numTeams_; team_index++)
+    for (int i = 0; i < numTeams_; i++)
     {
 
         vector<impalib_type> initial_forward_messages(maxStateIc_ + 1, zero_value),
@@ -77,37 +77,37 @@ void OrInequalityConstraint::oric_to_project_eq_constraint_update(vector<vector<
         stage_forward_messages_ORIC_project[0] = initial_forward_messages;
         
         // Calculate forward messages
-        for (int stage = 0; stage < numProjects_; stage++)
+        for (int s = 0; s < numProjects_; s++)
         {
-            stage_forward_messages_ORIC_project[stage + 1][0] = stage_forward_messages_ORIC_project[stage][0];
-            stage_forward_messages_ORIC_project[stage + 1][1] =
-                min(stage_forward_messages_ORIC_project[stage][1], stage_forward_messages_ORIC_project[stage][0]
-                                                                       + rEqConstraint2OricM[stage][team_index]
-                                                                       + mTeam2ORIC[team_index]);
+            stage_forward_messages_ORIC_project[s + 1][0] = stage_forward_messages_ORIC_project[s][0];
+            stage_forward_messages_ORIC_project[s + 1][1] =
+                min(stage_forward_messages_ORIC_project[s][1], stage_forward_messages_ORIC_project[s][0]
+                                                                       + rEqConstraint2OricM[s][i]
+                                                                       + mTeam2ORIC[i]);
         }
 
         // Set initial backward messages
         stage_backward_messages_ORIC_project[numProjects_] = initial_backward_messages;
 
         // Calculate backward messages
-        for (int stage = numProjects_ - 1; stage >= 0; stage--)
+        for (int s = numProjects_ - 1; s >= 0; s--)
         {
-            stage_backward_messages_ORIC_project[stage][0] =
-                min(stage_backward_messages_ORIC_project[stage + 1][0],
-                    stage_backward_messages_ORIC_project[stage + 1][1] + rEqConstraint2OricM[stage][team_index]
-                        + mTeam2ORIC[team_index]);
-            stage_backward_messages_ORIC_project[stage][1] = stage_backward_messages_ORIC_project[stage + 1][1];
+            stage_backward_messages_ORIC_project[s][0] =
+                min(stage_backward_messages_ORIC_project[s + 1][0],
+                    stage_backward_messages_ORIC_project[s + 1][1] + rEqConstraint2OricM[s][i]
+                        + mTeam2ORIC[i]);
+            stage_backward_messages_ORIC_project[s][1] = stage_backward_messages_ORIC_project[s + 1][1];
         }
 
-        for (int project_index = 0; project_index < numProjects_; project_index++)
+        for (int j = 0; j < numProjects_; j++)
         {
             impalib_type minimumValue                      = zero_value;
-            minimumValue                                   = min(stage_forward_messages_ORIC_project[project_index][1],
-                                                                 stage_backward_messages_ORIC_project[project_index + 1][0]);
+            minimumValue                                   = min(stage_forward_messages_ORIC_project[j][1],
+                                                                 stage_backward_messages_ORIC_project[j + 1][0]);
             minimumValue                                   = min(minimumValue, zero_value);
-            rOric2EqConstraintM[project_index][team_index] = mTeam2ORIC[team_index] - minimumValue;
-            rEqConstraint2ProjectM[project_index][team_index] =
-                rOric2EqConstraintM[project_index][team_index] + rRewardProject[project_index][team_index];
+            rOric2EqConstraintM[j][i] = mTeam2ORIC[i] - minimumValue;
+            rEqConstraint2ProjectM[j][i] =
+                rOric2EqConstraintM[j][i] + rRewardProject[j][i];
         }
     }
 }
@@ -123,17 +123,17 @@ void OrInequalityConstraint::oric_to_project_eq_constraint_update(vector<vector<
 void OrInequalityConstraint::oric_to_team_update(vector<vector<impalib_type>> &rEqConstraint2OricM,
                                                  vector<impalib_type>         &rOric2TeamM)
 {
-    for (int team_index = 0; team_index < rOric2TeamM.size(); team_index++)
+    for (int i = 0; i < rOric2TeamM.size(); i++)
     {
         impalib_type minValue = 1000000;
 
-        for (int project_index = 0; project_index < rEqConstraint2OricM.size(); project_index++)
+        for (int j = 0; j < rEqConstraint2OricM.size(); j++)
         {
-            if (rEqConstraint2OricM[project_index][team_index] < minValue)
+            if (rEqConstraint2OricM[j][i] < minValue)
             {
-                minValue = rEqConstraint2OricM[project_index][team_index];
+                minValue = rEqConstraint2OricM[j][i];
             }
         }
-        rOric2TeamM[team_index] = minValue;
+        rOric2TeamM[i] = minValue;
     }
 }

--- a/include/impalib/update_or_inequality_constraint.hpp
+++ b/include/impalib/update_or_inequality_constraint.hpp
@@ -62,23 +62,18 @@ void OrInequalityConstraint::oric_to_project_eq_constraint_update(vector<vector<
                                                                   vector<vector<impalib_type>> &rEqConstraint2ProjectM,
                                                                   vector<vector<impalib_type>> &rRewardProject)
 {
-    // Initialize forward and backward messages
     vector<vector<impalib_type>> stage_forward_messages_ORIC_project(numProjects_ + 1,
                                                                      vector<impalib_type>(maxStateIc_ + 1, zero_value));
     vector<vector<impalib_type>> stage_backward_messages_ORIC_project(
         numProjects_ + 1, vector<impalib_type>(maxStateIc_ + 1, zero_value));
 
-    // Iterate over each team
     for (int team_index = 0; team_index < numTeams_; team_index++)
     {
 
-        // Initialize forward and backward messages
         vector<impalib_type> initial_forward_messages(maxStateIc_ + 1, zero_value),
             initial_backward_messages(maxStateIc_ + 1, zero_value);
-        
-        // Set initial forward messages
-        fill(initial_forward_messages.begin() + 1, initial_forward_messages.end(), value_inf);
 
+        fill(initial_forward_messages.begin() + 1, initial_forward_messages.end(), value_inf);
         stage_forward_messages_ORIC_project[0] = initial_forward_messages;
         
         // Calculate forward messages
@@ -104,18 +99,13 @@ void OrInequalityConstraint::oric_to_project_eq_constraint_update(vector<vector<
             stage_backward_messages_ORIC_project[stage][1] = stage_backward_messages_ORIC_project[stage + 1][1];
         }
 
-        // Update messages from ORIC to project equality constraints and from project equality constraints to project inequality constraints
         for (int project_index = 0; project_index < numProjects_; project_index++)
         {
             impalib_type minimumValue                      = zero_value;
-            // Calculate the minimum value between forward and backward messages
             minimumValue                                   = min(stage_forward_messages_ORIC_project[project_index][1],
                                                                  stage_backward_messages_ORIC_project[project_index + 1][0]);
-            // Calculate the minimum value between previous minimum and zero
             minimumValue                                   = min(minimumValue, zero_value);
-            // Update messages from ORIC to project equality constraints
             rOric2EqConstraintM[project_index][team_index] = mTeam2ORIC[team_index] - minimumValue;
-            // Update messages from project equality constraints to project inequality constraints
             rEqConstraint2ProjectM[project_index][team_index] =
                 rOric2EqConstraintM[project_index][team_index] + rRewardProject[project_index][team_index];
         }
@@ -133,13 +123,10 @@ void OrInequalityConstraint::oric_to_project_eq_constraint_update(vector<vector<
 void OrInequalityConstraint::oric_to_team_update(vector<vector<impalib_type>> &rEqConstraint2OricM,
                                                  vector<impalib_type>         &rOric2TeamM)
 {
-    // Iterate over each team
     for (int team_index = 0; team_index < rOric2TeamM.size(); team_index++)
     {
-        // Initialize minimum value
         impalib_type minValue = 1000000;
 
-        // Find the minimum value among messages from project equality constraints to ORIC for this team
         for (int project_index = 0; project_index < rEqConstraint2OricM.size(); project_index++)
         {
             if (rEqConstraint2OricM[project_index][team_index] < minValue)
@@ -147,7 +134,6 @@ void OrInequalityConstraint::oric_to_team_update(vector<vector<impalib_type>> &r
                 minValue = rEqConstraint2OricM[project_index][team_index];
             }
         }
-        // Update message from ORIC to team with the minimum value
         rOric2TeamM[team_index] = minValue;
     }
 }

--- a/include/impalib/update_or_inequality_constraint.hpp
+++ b/include/impalib/update_or_inequality_constraint.hpp
@@ -11,22 +11,20 @@
 /**
  * Represents a class for the ORIC for Knapsack-MWM problem
  */
-class OrInequalityConstraint
-{
-private:
-    int numTeams_; ///< number of teams
-    int numDepartments_; ///< number of departments
-    int numProjects_; ///< number of projects
-    int maxStateIc_ = 1; ///< maximum state of inequality constraint (>=1)
+class OrInequalityConstraint {
+   private:
+    int numTeams_;        ///< number of teams
+    int numDepartments_;  ///< number of departments
+    int numProjects_;     ///< number of projects
+    int maxStateIc_ = 1;  ///< maximum state of inequality constraint (>=1)
 
-public:
-    void oric_to_project_eq_constraint_update(const vector<vector<impalib_type>> &, const vector<impalib_type> &,
-                                              vector<vector<impalib_type>> &, vector<vector<impalib_type>> &,
-                                              const vector<vector<impalib_type>> &); ///< update messages from ORIC to project equality constraint
+   public:
+    void messages_to_project_eq(const vector<vector<impalib_type>> &eq2oric, const vector<impalib_type> &team2oric, vector<vector<impalib_type>> &oric2eq, vector<vector<impalib_type>> &eq2proj,
+                                const vector<vector<impalib_type>> &reward_project);  ///< update messages from ORIC to project equality constraint
 
-    vector<impalib_type> oric_to_team_update(const vector<vector<impalib_type>> &); ///< calculate messages from team ORIC to team equality constraint
+    vector<impalib_type> messages_to_team_eq(const vector<vector<impalib_type>> &eq2oric);  ///< calculate messages from team ORIC to team equality constraint
 
-    OrInequalityConstraint(int N_DEPARTMENTS, int N_TEAMS, int N_PROJECTS); ///< constructor
+    OrInequalityConstraint(int N_DEPARTMENTS, int N_TEAMS, int N_PROJECTS);  ///< constructor
 };
 
 /**
@@ -38,76 +36,54 @@ public:
  * @param[out] numProjects_: N_PROJECTS
  * @param[out] numTeams_: N_TEAMS
  * @param[out] numDepartments_: N_DEPARTMENTS
- * 
+ *
  */
 
-OrInequalityConstraint::OrInequalityConstraint(const int N_DEPARTMENTS, const int N_TEAMS, const int N_PROJECTS)
-    : numProjects_(N_PROJECTS), numTeams_(N_TEAMS), numDepartments_(N_DEPARTMENTS){
-                                                    };
+OrInequalityConstraint::OrInequalityConstraint(const int N_DEPARTMENTS, const int N_TEAMS, const int N_PROJECTS) : numProjects_(N_PROJECTS), numTeams_(N_TEAMS), numDepartments_(N_DEPARTMENTS){};
 
 /**
  * Calculate messages from ORIC to project equality constraints for the Knapsack-MWM problem
  *
- * @param[in] rEqConstraint2OricM: messages from project equality constraint to ORIC
- * @param[in] mTeam2ORIC: messages from teams to ORIC
- * @param[out] rOric2EqConstraintM: messages from ORIC to project equality constraints
- * @param[in] rEqConstraint2ProjectM: messages from equality constraints to project inequality constraints
- * @param[in] rRewardProject: rewards for project equality constraints
- * 
+ * @param[in] eq2oric: messages from project equality constraint to ORIC
+ * @param[in] team2oric: messages from teams to ORIC
+ * @param[out] oric2eq: messages from ORIC to project equality constraints
+ * @param[in] eq2proj: messages from equality constraints to project inequality constraints
+ * @param[in] reward_project: rewards for project equality constraints
+ *
  */
 
-void OrInequalityConstraint::oric_to_project_eq_constraint_update(const vector<vector<impalib_type>> &rEqConstraint2OricM,
-                                                                  const vector<impalib_type>         &mTeam2ORIC,
-                                                                  vector<vector<impalib_type>> &rOric2EqConstraintM,
-                                                                  vector<vector<impalib_type>> &rEqConstraint2ProjectM,
-                                                                  const vector<vector<impalib_type>> &rRewardProject)
-{
-    vector<vector<impalib_type>> stage_forward_messages_ORIC_project(numProjects_ + 1,
-                                                                     vector<impalib_type>(maxStateIc_ + 1, zero_value));
-    vector<vector<impalib_type>> stage_backward_messages_ORIC_project(
-        numProjects_ + 1, vector<impalib_type>(maxStateIc_ + 1, zero_value));
+void OrInequalityConstraint::messages_to_project_eq(const vector<vector<impalib_type>> &eq2oric, const vector<impalib_type> &team2oric, vector<vector<impalib_type>> &oric2eq,
+                                                    vector<vector<impalib_type>> &eq2proj, const vector<vector<impalib_type>> &reward_project) {
+    vector<vector<impalib_type>> forward(numProjects_ + 1, vector<impalib_type>(maxStateIc_ + 1, zero_value));
+    vector<vector<impalib_type>> backward(numProjects_ + 1, vector<impalib_type>(maxStateIc_ + 1, zero_value));
 
-    for (int i = 0; i < numTeams_; i++)
-    {
-
-        vector<impalib_type> initial_forward_messages(maxStateIc_ + 1, zero_value),
-            initial_backward_messages(maxStateIc_ + 1, zero_value);
+    for (int i = 0; i < numTeams_; i++) {
+        vector<impalib_type> initial_forward_messages(maxStateIc_ + 1, zero_value), initial_backward_messages(maxStateIc_ + 1, zero_value);
 
         fill(initial_forward_messages.begin() + 1, initial_forward_messages.end(), value_inf);
-        stage_forward_messages_ORIC_project[0] = initial_forward_messages;
-        
+        forward[0] = initial_forward_messages;
+
         // Calculate forward messages
-        for (int s = 0; s < numProjects_; s++)
-        {
-            stage_forward_messages_ORIC_project[s + 1][0] = stage_forward_messages_ORIC_project[s][0];
-            stage_forward_messages_ORIC_project[s + 1][1] =
-                min(stage_forward_messages_ORIC_project[s][1], stage_forward_messages_ORIC_project[s][0]
-                                                                       + rEqConstraint2OricM[s][i]
-                                                                       + mTeam2ORIC[i]);
+        for (int s = 0; s < numProjects_; s++) {
+            forward[s + 1][0] = forward[s][0];
+            forward[s + 1][1] = min(forward[s][1], forward[s][0] + eq2oric[s][i] + team2oric[i]);
         }
 
         // Set initial backward messages
-        stage_backward_messages_ORIC_project[numProjects_] = initial_backward_messages;
+        backward[numProjects_] = initial_backward_messages;
 
         // Calculate backward messages
-        for (int s = numProjects_ - 1; s >= 0; s--)
-        {
-            stage_backward_messages_ORIC_project[s][0] =
-                min(stage_backward_messages_ORIC_project[s + 1][0],
-                    stage_backward_messages_ORIC_project[s + 1][1] + rEqConstraint2OricM[s][i]
-                        + mTeam2ORIC[i]);
-            stage_backward_messages_ORIC_project[s][1] = stage_backward_messages_ORIC_project[s + 1][1];
+        for (int s = numProjects_ - 1; s >= 0; s--) {
+            backward[s][0] = min(backward[s + 1][0], backward[s + 1][1] + eq2oric[s][i] + team2oric[i]);
+            backward[s][1] = backward[s + 1][1];
         }
 
-        for (int j = 0; j < numProjects_; j++)
-        {
-            impalib_type minimumValue                      = zero_value;
-            minimumValue                                   = min(stage_forward_messages_ORIC_project[j][1],
-                                                                 stage_backward_messages_ORIC_project[j + 1][0]);
-            minimumValue                                   = min(minimumValue, zero_value);
-            rOric2EqConstraintM[j][i] = mTeam2ORIC[i] - minimumValue;
-            rEqConstraint2ProjectM[j][i] =
-                rOric2EqConstraintM[j][i] + rRewardProject[j][i];
+        for (int j = 0; j < numProjects_; j++) {
+            impalib_type minimumValue = zero_value;
+            minimumValue = min(forward[j][1], backward[j + 1][0]);
+            minimumValue = min(minimumValue, zero_value);
+            oric2eq[j][i] = team2oric[i] - minimumValue;
+            eq2proj[j][i] = oric2eq[j][i] + reward_project[j][i];
         }
     }
 }
@@ -115,26 +91,22 @@ void OrInequalityConstraint::oric_to_project_eq_constraint_update(const vector<v
 /**
  * Calculate messages from ORIC to team equality constraints for the Knapsack-MWM problem
  *
- * @param[in] rEqConstraint2OricM: messages from project equality constraint to ORIC
+ * @param[in] eq2oric: messages from project equality constraint to ORIC
  * @param[out] rOric2TeamM: messages from ORIC to teams
- * 
+ *
  */
 
-vector<impalib_type> OrInequalityConstraint::oric_to_team_update(const vector<vector<impalib_type>> &rEqConstraint2OricM)
-{
-    vector<impalib_type> rOric2TeamM(numTeams_);
-    for (int i = 0; i < rOric2TeamM.size(); i++)
-    {
+vector<impalib_type> OrInequalityConstraint::messages_to_team_eq(const vector<vector<impalib_type>> &eq2oric) {
+    vector<impalib_type> oric2team(numTeams_);
+    for (int i = 0; i < oric2team.size(); i++) {
         impalib_type minValue = 1000000;
 
-        for (int j = 0; j < rEqConstraint2OricM.size(); j++)
-        {
-            if (rEqConstraint2OricM[j][i] < minValue)
-            {
-                minValue = rEqConstraint2OricM[j][i];
+        for (int j = 0; j < eq2oric.size(); j++) {
+            if (eq2oric[j][i] < minValue) {
+                minValue = eq2oric[j][i];
             }
         }
-        rOric2TeamM[i] = minValue;
+        oric2team[i] = minValue;
     }
-    return rOric2TeamM;
+    return oric2team;
 }

--- a/include/impalib/update_or_inequality_constraint.hpp
+++ b/include/impalib/update_or_inequality_constraint.hpp
@@ -24,7 +24,7 @@ public:
                                               vector<vector<impalib_type>> &, vector<vector<impalib_type>> &,
                                               vector<vector<impalib_type>> &); ///< update messages from ORIC to project equality constraint
 
-    void oric_to_team_update(vector<vector<impalib_type>> &, vector<impalib_type> &); ///< calculate messages from team ORIC to team equality constraint
+    vector<impalib_type> oric_to_team_update(vector<vector<impalib_type>> &); ///< calculate messages from team ORIC to team equality constraint
 
     OrInequalityConstraint(const int N_DEPARTMENTS, const int N_TEAMS, const int N_PROJECTS); ///< constructor
 };
@@ -120,9 +120,9 @@ void OrInequalityConstraint::oric_to_project_eq_constraint_update(vector<vector<
  * 
  */
 
-void OrInequalityConstraint::oric_to_team_update(vector<vector<impalib_type>> &rEqConstraint2OricM,
-                                                 vector<impalib_type>         &rOric2TeamM)
+vector<impalib_type> OrInequalityConstraint::oric_to_team_update(vector<vector<impalib_type>> &rEqConstraint2OricM)
 {
+    vector<impalib_type> rOric2TeamM(numTeams_);
     for (int i = 0; i < rOric2TeamM.size(); i++)
     {
         impalib_type minValue = 1000000;
@@ -136,4 +136,5 @@ void OrInequalityConstraint::oric_to_team_update(vector<vector<impalib_type>> &r
         }
         rOric2TeamM[i] = minValue;
     }
+    return rOric2TeamM;
 }

--- a/include/impalib/update_or_inequality_constraint.hpp
+++ b/include/impalib/update_or_inequality_constraint.hpp
@@ -33,13 +33,10 @@ class OrInequalityConstraint {
  * @param[in] N_DEPARTMENTS: number of departments
  * @param[in] N_TEAMS: number of teams
  * @param[in] N_PROJECTS: number of projects
- * @param[out] numProjects_: N_PROJECTS
- * @param[out] numTeams_: N_TEAMS
- * @param[out] numDepartments_: N_DEPARTMENTS
  *
  */
 
-OrInequalityConstraint::OrInequalityConstraint(const int N_DEPARTMENTS, const int N_TEAMS, const int N_PROJECTS) : numProjects_(N_PROJECTS), numTeams_(N_TEAMS), numDepartments_(N_DEPARTMENTS){};
+inline OrInequalityConstraint::OrInequalityConstraint(const int N_DEPARTMENTS, const int N_TEAMS, const int N_PROJECTS) : numProjects_(N_PROJECTS), numTeams_(N_TEAMS), numDepartments_(N_DEPARTMENTS){};
 
 /**
  * Calculate messages from ORIC to project equality constraints for the Knapsack-MWM problem
@@ -51,8 +48,7 @@ OrInequalityConstraint::OrInequalityConstraint(const int N_DEPARTMENTS, const in
  * @param[in] reward_project: rewards for project equality constraints
  *
  */
-
-void OrInequalityConstraint::messages_to_project_eq(const vector<vector<impalib_type>> &eq2oric, const vector<impalib_type> &team2oric, vector<vector<impalib_type>> &oric2eq,
+inline void OrInequalityConstraint::messages_to_project_eq(const vector<vector<impalib_type>> &eq2oric, const vector<impalib_type> &team2oric, vector<vector<impalib_type>> &oric2eq,
                                                     vector<vector<impalib_type>> &eq2proj, const vector<vector<impalib_type>> &reward_project) {
     vector<vector<impalib_type>> forward(numProjects_ + 1, vector<impalib_type>(maxStateIc_ + 1, zero_value));
     vector<vector<impalib_type>> backward(numProjects_ + 1, vector<impalib_type>(maxStateIc_ + 1, zero_value));
@@ -92,11 +88,10 @@ void OrInequalityConstraint::messages_to_project_eq(const vector<vector<impalib_
  * Calculate messages from ORIC to team equality constraints for the Knapsack-MWM problem
  *
  * @param[in] eq2oric: messages from project equality constraint to ORIC
- * @param[out] rOric2TeamM: messages from ORIC to teams
+ * @returns : messages from ORIC to teams
  *
  */
-
-vector<impalib_type> OrInequalityConstraint::messages_to_team_eq(const vector<vector<impalib_type>> &eq2oric) {
+inline vector<impalib_type> OrInequalityConstraint::messages_to_team_eq(const vector<vector<impalib_type>> &eq2oric) {
     vector<impalib_type> oric2team(numTeams_);
     for (int i = 0; i < oric2team.size(); i++) {
         impalib_type minValue = 1000000;

--- a/include/impalib/update_or_inequality_constraint.hpp
+++ b/include/impalib/update_or_inequality_constraint.hpp
@@ -20,13 +20,13 @@ private:
     int maxStateIc_ = 1; ///< maximum state of inequality constraint (>=1)
 
 public:
-    void oric_to_project_eq_constraint_update(vector<vector<impalib_type>> &, vector<impalib_type> &,
+    void oric_to_project_eq_constraint_update(const vector<vector<impalib_type>> &, const vector<impalib_type> &,
                                               vector<vector<impalib_type>> &, vector<vector<impalib_type>> &,
-                                              vector<vector<impalib_type>> &); ///< update messages from ORIC to project equality constraint
+                                              const vector<vector<impalib_type>> &); ///< update messages from ORIC to project equality constraint
 
-    vector<impalib_type> oric_to_team_update(vector<vector<impalib_type>> &); ///< calculate messages from team ORIC to team equality constraint
+    vector<impalib_type> oric_to_team_update(const vector<vector<impalib_type>> &); ///< calculate messages from team ORIC to team equality constraint
 
-    OrInequalityConstraint(const int N_DEPARTMENTS, const int N_TEAMS, const int N_PROJECTS); ///< constructor
+    OrInequalityConstraint(int N_DEPARTMENTS, int N_TEAMS, int N_PROJECTS); ///< constructor
 };
 
 /**
@@ -56,11 +56,11 @@ OrInequalityConstraint::OrInequalityConstraint(const int N_DEPARTMENTS, const in
  * 
  */
 
-void OrInequalityConstraint::oric_to_project_eq_constraint_update(vector<vector<impalib_type>> &rEqConstraint2OricM,
-                                                                  vector<impalib_type>         &mTeam2ORIC,
+void OrInequalityConstraint::oric_to_project_eq_constraint_update(const vector<vector<impalib_type>> &rEqConstraint2OricM,
+                                                                  const vector<impalib_type>         &mTeam2ORIC,
                                                                   vector<vector<impalib_type>> &rOric2EqConstraintM,
                                                                   vector<vector<impalib_type>> &rEqConstraint2ProjectM,
-                                                                  vector<vector<impalib_type>> &rRewardProject)
+                                                                  const vector<vector<impalib_type>> &rRewardProject)
 {
     vector<vector<impalib_type>> stage_forward_messages_ORIC_project(numProjects_ + 1,
                                                                      vector<impalib_type>(maxStateIc_ + 1, zero_value));
@@ -120,7 +120,7 @@ void OrInequalityConstraint::oric_to_project_eq_constraint_update(vector<vector<
  * 
  */
 
-vector<impalib_type> OrInequalityConstraint::oric_to_team_update(vector<vector<impalib_type>> &rEqConstraint2OricM)
+vector<impalib_type> OrInequalityConstraint::oric_to_team_update(const vector<vector<impalib_type>> &rEqConstraint2OricM)
 {
     vector<impalib_type> rOric2TeamM(numTeams_);
     for (int i = 0; i < rOric2TeamM.size(); i++)

--- a/src/impa/Wrapper.cpp
+++ b/src/impa/Wrapper.cpp
@@ -49,12 +49,12 @@ extern "C" void WrapperKcMwm(const int NUM_ITERATIONS, const int NUM_DEPARTMENTS
     model_graph.iterate(pNON_ZERO_WEIGHT_INDICES_SIZES_PY);
 
     // Copy the extrinsic output for each team to the provided variable
-    copy(model_graph.outputs.ExtrinsicOutputTeam.begin(), model_graph.outputs.ExtrinsicOutputTeam.begin() + NUM_TEAMS,
+    copy(model_graph.outputs.extrinsic.begin(), model_graph.outputs.extrinsic.begin() + NUM_TEAMS,
          pExtrinsic_output_team);
     
     // Copy the intrinsic output for each team-project pair to the provided variable
-    copy(model_graph.outputs.IntrinsicOutMwm.begin(),
-         model_graph.outputs.IntrinsicOutMwm.begin() + NUM_TEAMS * NUM_PROJECTS, pIntrinsic_out_mwm);
+    copy(model_graph.outputs.intrinsic.begin(),
+         model_graph.outputs.intrinsic.begin() + NUM_TEAMS * NUM_PROJECTS, pIntrinsic_out_mwm);
 }
 
 /**
@@ -111,16 +111,16 @@ extern "C" void WrapperTsp(const int NUM_ITERATIONS, const int NUM_NODES, const 
                            pEdge_ec_to_degree_constraint_m_py, pEDGE_DEGREE_CONSTRAINT_COST_PY);
 
     // Perform IMPA on the relaxed graph
-    model_graph.iterate_relaxed_graph();
+    auto out = model_graph.iterate_relaxed_graph();
 
     // Check and perform augmentation if needed
-    if (!model_graph.subtourConstraintsSatisfiedFlag && AUGMENTATION_FLAG)
+    if (!out.subtourConstraintsSatisfiedFlag && AUGMENTATION_FLAG)
     {
         model_graph.perform_augmentation(MAX_AUGM_COUNT);
 
     }
 
     // Process the outputs of the model
-    model_graph.process_ouputs(pExtrinsic_output_edge_ec, pNum_augmentations, pNum_added_constraints, pTour_impa, pCost_impa, pNo_improv_sol_count_exc_flag, \
+    model_graph.process_outputs(pExtrinsic_output_edge_ec, pNum_augmentations, pNum_added_constraints, pTour_impa, pCost_impa, pNo_improv_sol_count_exc_flag, \
                               pNo_cons_loops_count_exc_flag, pSol_osc_count_exc_flag, pSelected_edges, pSelected_edges_size, pSubtour_paths, pSubtour_paths_size);
 }

--- a/test/README.md
+++ b/test/README.md
@@ -20,7 +20,7 @@
 
     - Navigate to "impalib_unit_tests.py" and call the function unit test "ut_class.ut_function()" based on its function name $N$.
     
-    - Example: Function $F$ "degree_constraint_to_edge_ec_update()" with function name $N$ "DegreeConstraint2EdgeEcUpdate" is already implemented for class $C$ with file "ut_update_degree_constraint.py". Notice that $F$ is first called in "impalib_unit_tests.py" based on its function name. The unit test of $F$ in "ut_update_degree_constraint.py" will generate the Python input and output files.
+    - Example: Function $F$ "messages_to_edge_ec()" with function name $N$ "DegreeConstraint2EdgeEcUpdate" is already implemented for class $C$ with file "ut_update_degree_constraint.py". Notice that $F$ is first called in "impalib_unit_tests.py" based on its function name. The unit test of $F$ in "ut_update_degree_constraint.py" will generate the Python input and output files.
 
     - Note that "impalib_unit_tests.py" file takes some inputs to process the python unit testing. These are user specific inputs (number of nodes in TSP, etc.)
 
@@ -34,7 +34,7 @@
 
     - Next, navigate to "test/src/impalib_unit_tests_kc_mwm.cpp" or "test/src/impalib_unit_tests_tsp.cpp" and call the function unit test "ut_function()".
 
-    - Example: Function $F$ "degree_constraint_to_edge_ec_update()" with function name $N$ "DegreeConstraint2EdgeEcUpdate" is already implemented for class $C$ with file "ut_update_degree_constraint.hpp". Notice that $F$ is called in "impalib_unit_tests_tsp.cpp" based on its function name. The unit test of $F$ in "ut_update_degree_constraint.hpp" will read the input files from "test/ut_inputs/" and generate the output files in "test/ut_results/". Note that some general variables are exported in "unit_test_kc_mwm.sh" or "unit_test_tsp.sh", and these will be read in the unit test functions. These inputs are common across various unit tests.
+    - Example: Function $F$ "messages_to_edge_ec()" with function name $N$ "DegreeConstraint2EdgeEcUpdate" is already implemented for class $C$ with file "ut_update_degree_constraint.hpp". Notice that $F$ is called in "impalib_unit_tests_tsp.cpp" based on its function name. The unit test of $F$ in "ut_update_degree_constraint.hpp" will read the input files from "test/ut_inputs/" and generate the output files in "test/ut_results/". Note that some general variables are exported in "unit_test_kc_mwm.sh" or "unit_test_tsp.sh", and these will be read in the unit test functions. These inputs are common across various unit tests.
 
   - Step $4$:
     - "python3 ut_methods_utils.py" takes the function, and is called to read the outputs files of the Python and C++ codes, and check agreement or not.

--- a/test/include/ut_graphical_model.hpp
+++ b/test/include/ut_graphical_model.hpp
@@ -79,14 +79,14 @@ void ut_iterate_kc_mwm(string& ut_name){
     fstream file_output1("../ut_results/extrinsic_output_team_wrapper", ios::out | ios::binary | ios:: trunc);
     if (file_output1.is_open()) {
         for (int i=0; i<N_TEAMS; i++){
-            file_output1.write((char*)(&model_graph.outputs.ExtrinsicOutputTeam[i]), sizeof(model_graph.outputs.ExtrinsicOutputTeam[i]));}
+            file_output1.write((char*)(&model_graph.outputs.extrinsic[i]), sizeof(model_graph.outputs.extrinsic[i]));}
             file_output1.close();}
     else {cout << "Error! File cannot be opened!" << "\n";}
 
     fstream file_output2("../ut_results/intrinsic_out_mwm_wrapper", ios::out | ios::binary | ios:: trunc);
     if (file_output2.is_open()) {
         for (int i=0; i<N_TEAMS*N_PROJECTS; i++){
-            file_output2.write((char*)(&model_graph.outputs.IntrinsicOutMwm[i]), sizeof(model_graph.outputs.IntrinsicOutMwm[i]));}
+            file_output2.write((char*)(&model_graph.outputs.intrinsic[i]), sizeof(model_graph.outputs.intrinsic[i]));}
             file_output2.close();}
     else {cout << "Error! File cannot be opened!" << "\n";}
 }
@@ -154,14 +154,14 @@ void ut_iterate_sample_graph_kc_mwm(string& ut_name){
     fstream file_output1("../ut_results/extrinsic_output_team_wrapper", ios::out | ios::binary | ios:: trunc);
     if (file_output1.is_open()) {
         for (int i=0; i<N_TEAMS; i++){
-            file_output1.write((char*)(&model_graph.outputs.ExtrinsicOutputTeam[i]), sizeof(model_graph.outputs.ExtrinsicOutputTeam[i]));}
+            file_output1.write((char*)(&model_graph.outputs.extrinsic[i]), sizeof(model_graph.outputs.extrinsic[i]));}
             file_output1.close();}
     else {cout << "Error! File cannot be opened!" << "\n";}
 
     fstream file_output2("../ut_results/intrinsic_out_mwm_wrapper", ios::out | ios::binary | ios:: trunc);
     if (file_output2.is_open()) {
         for (int i=0; i<N_TEAMS*N_PROJECTS; i++){
-            file_output2.write((char*)(&model_graph.outputs.IntrinsicOutMwm[i]), sizeof(model_graph.outputs.IntrinsicOutMwm[i]));}
+            file_output2.write((char*)(&model_graph.outputs.intrinsic[i]), sizeof(model_graph.outputs.intrinsic[i]));}
             file_output2.close();}
     else {cout << "Error! File cannot be opened!" << "\n";}
 }
@@ -231,7 +231,7 @@ void ut_model_graph_tsp(string& ut_name){
         fstream file_output("../ut_results/intrinsic_out_edge_ec_wrapper", ios::out | ios::binary | ios:: trunc);
             if (file_output.is_open()) {
                 for (int i=0; i<N_EDGE_VARIABLES; i++){
-                    file_output.write((char*)(&model_graph.outputs.IntrinsicOutputEdgeEc[i]), sizeof(model_graph.outputs.IntrinsicOutputEdgeEc[i]));}
+                    file_output.write((char*)(&model_graph.outputs.intrinsic[i]), sizeof(model_graph.outputs.intrinsic[i]));}
                     file_output.close();}
             else {cout << "Error! File cannot be opened!" << "\n";}
 
@@ -261,7 +261,7 @@ void ut_model_graph_tsp(string& ut_name){
         fstream file_output("../ut_results/intrinsic_out_edge_ec_wrapper", ios::out | ios::binary | ios:: trunc);
             if (file_output.is_open()) {
                 for (int i=0; i<N_EDGE_VARIABLES; i++){
-                    file_output.write((char*)(&model_graph.outputs.IntrinsicOutputEdgeEc[i]), sizeof(model_graph.outputs.IntrinsicOutputEdgeEc[i]));}
+                    file_output.write((char*)(&model_graph.outputs.intrinsic[i]), sizeof(model_graph.outputs.intrinsic[i]));}
                     file_output.close();}
             else {cout << "Error! File cannot be opened!" << "\n";}
 

--- a/test/include/ut_graphical_model.hpp
+++ b/test/include/ut_graphical_model.hpp
@@ -250,9 +250,9 @@ void ut_model_graph_tsp(string& ut_name){
 
         model_graph.initialize(edge_connections_pure, cost_edge_variable_pure, cost_matrix_pure, edge_ec_to_degree_constraint_m_pure, edge_degree_constraint_cost_pure);
 
-        model_graph.iterate_relaxed_graph();
+        auto result = model_graph.iterate_relaxed_graph();
 
-        if (!model_graph.subtourConstraintsSatisfiedFlag && AUGMENTATION_FLAG)
+        if (!result.subtourConstraintsSatisfiedFlag && AUGMENTATION_FLAG)
         {
             model_graph.perform_augmentation(MAX_AUGM_COUNT);
 

--- a/test/include/ut_input_output.hpp
+++ b/test/include/ut_input_output.hpp
@@ -52,8 +52,7 @@ void ut_input_output_kc_mwm(string& ut_name){
         vector<impalib_type> oric_to_team_m(N_TEAMS,zero_value);
         copy(oric_to_team_m_pure, oric_to_team_m_pure + N_TEAMS, oric_to_team_m.begin());
 
-        
-        outputs.extrinsic_output_team_update(extrinsic_output_department, oric_to_team_m);
+        outputs.update_extrinsic(extrinsic_output_department, oric_to_team_m);
 
         fstream file_output("../ut_results/extrinsic_output_team_wrapper", ios::out | ios::binary | ios:: trunc);
                 if (file_output.is_open()) {
@@ -82,7 +81,7 @@ void ut_input_output_kc_mwm(string& ut_name){
         copy ( project_to_eq_constraint_m_pure + N_TEAMS*project_index, project_to_eq_constraint_m_pure+N_TEAMS*(project_index+1), project_to_eq_constraint_m[project_index].begin() );
         }
 
-        outputs.intrinsic_out_mwm_update(oric_to_eq_constraint_m, project_to_eq_constraint_m, reward_project);
+        outputs.update_intrinsic(oric_to_eq_constraint_m, project_to_eq_constraint_m, reward_project);
 
         fstream file_output("../ut_results/intrinsic_out_mwm_wrapper", ios::out | ios::binary | ios:: trunc);
             if (file_output.is_open()) {
@@ -123,8 +122,7 @@ void ut_input_output_tsp(string& ut_name){
     OutputsTsp outputs(N_NODES, N_EDGE_VARIABLES);
 
     if (ut_name == "ExtrinsicOutputEdgeEcRelaxedGraphUpdate"){
-        
-        outputs.extrinsic_output_edge_ec_relaxed_graph_update(degree_constraint_to_eq_constraint_m);
+        outputs.update_extrinsic_relaxed(degree_constraint_to_eq_constraint_m);
         
         fstream file_output("../ut_results/extrinsic_output_edge_ec_relaxed_graph_wrapper", ios::out | ios::binary | ios:: trunc);
                 if (file_output.is_open()) {
@@ -145,7 +143,7 @@ void ut_input_output_tsp(string& ut_name){
         copy ( subtour_constraints_to_edge_ec_m_pure + N_EDGE_VARIABLES*subtour_index, subtour_constraints_to_edge_ec_m_pure+N_EDGE_VARIABLES*(subtour_index+1), subtour_constraints_to_edge_ec_m[subtour_index].begin() );
         }
 
-        outputs.extrinsic_output_edge_ec_augmented_graph_update(degree_constraint_to_eq_constraint_m, subtour_constraints_to_edge_ec_m);
+        outputs.update_extrinsic_augmented(degree_constraint_to_eq_constraint_m, subtour_constraints_to_edge_ec_m);
 
         fstream file_output("../ut_results/extrinsic_output_edge_ec_augmented_graph_wrapper", ios::out | ios::binary | ios:: trunc);
             if (file_output.is_open()) {

--- a/test/include/ut_input_output.hpp
+++ b/test/include/ut_input_output.hpp
@@ -57,7 +57,7 @@ void ut_input_output_kc_mwm(string& ut_name){
         fstream file_output("../ut_results/extrinsic_output_team_wrapper", ios::out | ios::binary | ios:: trunc);
                 if (file_output.is_open()) {
                     for (int i=0; i<N_TEAMS; i++){
-                        file_output.write((char*)(&outputs.ExtrinsicOutputTeam[i]), sizeof(outputs.ExtrinsicOutputTeam[i]));}
+                        file_output.write((char*)(&outputs.extrinsic[i]), sizeof(outputs.extrinsic[i]));}
                         file_output.close();}
                 else {cout << "Error! File cannot be opened!" << "\n";}
     
@@ -86,7 +86,7 @@ void ut_input_output_kc_mwm(string& ut_name){
         fstream file_output("../ut_results/intrinsic_out_mwm_wrapper", ios::out | ios::binary | ios:: trunc);
             if (file_output.is_open()) {
                 for (int i=0; i<N_PROJECTS*N_TEAMS; i++){
-                        file_output.write((char*)(&outputs.IntrinsicOutMwm[i]), sizeof(outputs.IntrinsicOutMwm[i]));}
+                        file_output.write((char*)(&outputs.intrinsic[i]), sizeof(outputs.intrinsic[i]));}
                         file_output.close();}
                 else {cout << "Error! File cannot be opened!" << "\n";}
 
@@ -127,7 +127,7 @@ void ut_input_output_tsp(string& ut_name){
         fstream file_output("../ut_results/extrinsic_output_edge_ec_relaxed_graph_wrapper", ios::out | ios::binary | ios:: trunc);
                 if (file_output.is_open()) {
                     for (int i=0; i<N_EDGE_VARIABLES; i++){
-                        file_output.write((char*)(&outputs.ExtrinsicOutputEdgeEc[i]), sizeof(outputs.ExtrinsicOutputEdgeEc[i]));}
+                        file_output.write((char*)(&outputs.extrinsic[i]), sizeof(outputs.extrinsic[i]));}
                         file_output.close();}
                 else {cout << "Error! File cannot be opened!" << "\n";}
     
@@ -148,7 +148,7 @@ void ut_input_output_tsp(string& ut_name){
         fstream file_output("../ut_results/extrinsic_output_edge_ec_augmented_graph_wrapper", ios::out | ios::binary | ios:: trunc);
             if (file_output.is_open()) {
                 for (int i=0; i<N_EDGE_VARIABLES; i++){
-                        file_output.write((char*)(&outputs.ExtrinsicOutputEdgeEc[i]), sizeof(outputs.ExtrinsicOutputEdgeEc[i]));}
+                        file_output.write((char*)(&outputs.extrinsic[i]), sizeof(outputs.extrinsic[i]));}
                         file_output.close();}
                 else {cout << "Error! File cannot be opened!" << "\n";}
     }

--- a/test/include/ut_knapsack.hpp
+++ b/test/include/ut_knapsack.hpp
@@ -165,10 +165,11 @@ void ut_extrinsic_output_department(string& ut_name){
             copy ( stage_backward_messages_pure + (max_state_department+1)*i, stage_backward_messages_pure + (max_state_department+1)*(i+1), stage_backward_messages[i].begin() );
         }
 
-        modelKnapsacks.extrinsic_output_department_lhs(teams_weights_per_department,
+        auto extrinsic_out = modelKnapsacks.extrinsic_output_department_lhs(teams_weights_per_department[department_index],
                             stage_forward_messages, team_to_knapsack_m,
                             department_index, stage_backward_messages,
-                            max_state_department, extrinsicOutputDepartment);
+                            max_state_department);
+        extrinsicOutputDepartment[department_index] = extrinsic_out;
     }
         
         fstream file_output("../ut_results/extrinsic_output_department_wrapper", ios::out | ios::binary | ios:: trunc);
@@ -301,7 +302,7 @@ void ut_process_extrinsic_output_department(string& ut_name){
         for (int department_index=0; department_index<N_DEPARTMENTS; department_index++){
             modelKnapsacks.process_extrinsic_output_department(department_index,
                                     iter, 
-                                    extrinsic_output_department_dummy, extrinsic_output_department);
+                                    extrinsic_output_department_dummy[department_index], extrinsic_output_department);
         }
     }
 

--- a/test/include/ut_knapsack.hpp
+++ b/test/include/ut_knapsack.hpp
@@ -298,9 +298,9 @@ void ut_process_extrinsic_output_department(string& ut_name){
 
     for (int iter=0; iter<N_ITER; iter++){
         for (int department_index=0; department_index<N_DEPARTMENTS; department_index++){
-            modelKnapsacks.process_extrinsic_output_department(department_index,
+            extrinsic_output_department[department_index] = modelKnapsacks.process_extrinsic_output_department(department_index,
                                     iter, 
-                                    extrinsic_output_department_dummy[department_index], extrinsic_output_department[department_index]);
+                                    extrinsic_output_department_dummy[department_index]);
         }
     }
 

--- a/test/include/ut_knapsack.hpp
+++ b/test/include/ut_knapsack.hpp
@@ -74,11 +74,13 @@ void ut_forward_backward(string& ut_name){
 
     for (int department_index = 0; department_index<N_DEPARTMENTS; department_index++){
         int max_state_department = Nu[department_index];
+        auto& idx_nonzero_dept = non_zero_weight_indices[department_index];
+        auto& team_weights = teams_weights_per_department[department_index];
         if (ut_name == "KnapsackForward"){
             vector<vector<impalib_type>> stage_forward_messages(N_TEAMS+1, vector<impalib_type>(max_state_department+1,zero_value));
             modelKnapsacks.forward(department_index, stage_forward_messages, max_state_department,
-            non_zero_weight_indices, non_zero_weight_indices_sizes_pure,
-            teams_weights_per_department, team_to_knapsack_m);
+            idx_nonzero_dept, non_zero_weight_indices_sizes_pure,
+            team_weights, team_to_knapsack_m);
             fstream file_output("../ut_results/forward_wrapper"+ std::to_string(department_index), ios::out | ios::binary | ios:: trunc);
             if (file_output.is_open()) {
                 for (int i=0; i<N_TEAMS+1; i++){
@@ -92,8 +94,8 @@ void ut_forward_backward(string& ut_name){
         else if (ut_name == "KnapsackBackward"){
             vector<vector<impalib_type>> stage_backward_messages(N_TEAMS+1, vector<impalib_type>(max_state_department+1,zero_value));
             modelKnapsacks.backward(department_index, stage_backward_messages, max_state_department,
-            non_zero_weight_indices, non_zero_weight_indices_sizes_pure,
-            teams_weights_per_department, team_to_knapsack_m);
+            idx_nonzero_dept, non_zero_weight_indices_sizes_pure,
+            team_weights, team_to_knapsack_m);
             
             fstream file_output("../ut_results/backward_wrapper"+ std::to_string(department_index), ios::out | ios::binary | ios:: trunc);
             if (file_output.is_open()) {

--- a/test/include/ut_knapsack.hpp
+++ b/test/include/ut_knapsack.hpp
@@ -77,8 +77,7 @@ void ut_forward_backward(string& ut_name){
         auto& idx_nonzero_dept = non_zero_weight_indices[department_index];
         auto& team_weights = teams_weights_per_department[department_index];
         if (ut_name == "KnapsackForward"){
-            vector<vector<impalib_type>> stage_forward_messages(N_TEAMS+1, vector<impalib_type>(max_state_department+1,zero_value));
-            modelKnapsacks.forward(department_index, stage_forward_messages, max_state_department,
+            auto stage_forward_messages = modelKnapsacks.forward(department_index, max_state_department,
             idx_nonzero_dept, non_zero_weight_indices_sizes_pure,
             team_weights, team_to_knapsack_m);
             fstream file_output("../ut_results/forward_wrapper"+ std::to_string(department_index), ios::out | ios::binary | ios:: trunc);
@@ -92,8 +91,7 @@ void ut_forward_backward(string& ut_name){
         }
 
         else if (ut_name == "KnapsackBackward"){
-            vector<vector<impalib_type>> stage_backward_messages(N_TEAMS+1, vector<impalib_type>(max_state_department+1,zero_value));
-            modelKnapsacks.backward(department_index, stage_backward_messages, max_state_department,
+            auto stage_backward_messages = modelKnapsacks.backward(department_index, max_state_department,
             idx_nonzero_dept, non_zero_weight_indices_sizes_pure,
             team_weights, team_to_knapsack_m);
             
@@ -302,7 +300,7 @@ void ut_process_extrinsic_output_department(string& ut_name){
         for (int department_index=0; department_index<N_DEPARTMENTS; department_index++){
             modelKnapsacks.process_extrinsic_output_department(department_index,
                                     iter, 
-                                    extrinsic_output_department_dummy[department_index], extrinsic_output_department);
+                                    extrinsic_output_department_dummy[department_index], extrinsic_output_department[department_index]);
         }
     }
 

--- a/test/include/ut_project_inequality_constraint.hpp
+++ b/test/include/ut_project_inequality_constraint.hpp
@@ -36,10 +36,8 @@ void ut_project_ineq_constraint(string& ut_name){
             for (int project_index=0; project_index<N_PROJECTS; project_index++){
                 copy ( eq_constraint_to_project_m_pure + N_TEAMS*project_index, eq_constraint_to_project_m_pure + N_TEAMS*(project_index+1), eq_constraint_to_project_m[project_index].begin() );
             }
-            
-            vector<vector<impalib_type>> project_to_eq_constraint_m(N_PROJECTS, vector<impalib_type>(N_TEAMS, zero_value));
 
-            projectIneqConstraint.project_inequality_constraint_update(eq_constraint_to_project_m, project_to_eq_constraint_m);
+            auto project_to_eq_constraint_m = projectIneqConstraint.messages_to_equality(eq_constraint_to_project_m);
 
             fstream file_output("../ut_results/project_to_eq_constraint_m_wrapper", ios::out | ios::binary | ios:: trunc);
             if (file_output.is_open()) {

--- a/test/include/ut_subtour_elimination_constraint.hpp
+++ b/test/include/ut_subtour_elimination_constraint.hpp
@@ -64,7 +64,7 @@ void ut_subtour_constraint(string& ut_name){
         
         vector<vector<impalib_type>> subtour_constraints_to_edge_ec_m(N_SUBTOURS, vector<impalib_type>(N_EDGE_VARIABLES, zero_value));
 
-        modelSubtourConstraint.subtour_constraints_to_edge_ec_update(edge_ec_to_subtour_constraints_m, delta_S_indices_list, subtour_constraints_to_edge_ec_m);
+        modelSubtourConstraint.messages_to_edge_ec(edge_ec_to_subtour_constraints_m, delta_S_indices_list, subtour_constraints_to_edge_ec_m);
         
         fstream file_output("../ut_results/subtour_constraints_to_edge_ec_m_wrapper", ios::out | ios::binary | ios:: trunc);
             if (file_output.is_open()) {

--- a/test/include/ut_update_degree_constraint.hpp
+++ b/test/include/ut_update_degree_constraint.hpp
@@ -51,10 +51,8 @@ void ut_degree_constraint(string& ut_name){
     DegreeConstraint modelDegreeConstraint(N_NODES, N_EDGE_VARIABLES, FILT_FLAG, ALPHA);
     
     if (ut_name == "DegreeConstraint2EdgeEcUpdate"){
-        
-        vector<vector<impalib_type>> degree_constraint_to_eq_constraint_m(N_EDGE_VARIABLES, vector<impalib_type>(N_NODES, zero_value));
 
-        modelDegreeConstraint.messages_to_edge_ec(edge_ec_to_degree_constraint_m, edge_connections, degree_constraint_to_eq_constraint_m);
+        auto degree_constraint_to_eq_constraint_m = modelDegreeConstraint.messages_to_edge_ec(edge_ec_to_degree_constraint_m, edge_connections);
         
         fstream file_output("../ut_results/degree_constraint_to_eq_constraint_m_wrapper", ios::out | ios::binary | ios:: trunc);
             if (file_output.is_open()) {

--- a/test/include/ut_update_degree_constraint.hpp
+++ b/test/include/ut_update_degree_constraint.hpp
@@ -54,7 +54,7 @@ void ut_degree_constraint(string& ut_name){
         
         vector<vector<impalib_type>> degree_constraint_to_eq_constraint_m(N_EDGE_VARIABLES, vector<impalib_type>(N_NODES, zero_value));
 
-        modelDegreeConstraint.degree_constraint_to_edge_ec_update(edge_ec_to_degree_constraint_m, edge_connections, degree_constraint_to_eq_constraint_m);
+        modelDegreeConstraint.messages_to_edge_ec(edge_ec_to_degree_constraint_m, edge_connections, degree_constraint_to_eq_constraint_m);
         
         fstream file_output("../ut_results/degree_constraint_to_eq_constraint_m_wrapper", ios::out | ios::binary | ios:: trunc);
             if (file_output.is_open()) {

--- a/test/include/ut_update_equality_constraint.hpp
+++ b/test/include/ut_update_equality_constraint.hpp
@@ -52,7 +52,7 @@ void ut_eq_constraint_kc_mwm(string& ut_name){
             copy ( extrinsic_output_department_pure + N_TEAMS*department_index, extrinsic_output_department_pure + N_TEAMS*(department_index+1), extrinsic_output_department[department_index].begin() );
         }
 
-            modelEqConstraint.team_eq_constraint_to_oric_update(extrinsic_output_department, team_to_oric_m, reward_team);
+            team_to_oric_m = modelEqConstraint.team_eq_constraint_to_oric_update(extrinsic_output_department, reward_team);
 
             fstream file_output("../ut_results/team_to_oric_m_wrapper", ios::out | ios::binary | ios:: trunc);
                 if (file_output.is_open()) {

--- a/test/include/ut_update_equality_constraint.hpp
+++ b/test/include/ut_update_equality_constraint.hpp
@@ -52,7 +52,7 @@ void ut_eq_constraint_kc_mwm(string& ut_name){
             copy ( extrinsic_output_department_pure + N_TEAMS*department_index, extrinsic_output_department_pure + N_TEAMS*(department_index+1), extrinsic_output_department[department_index].begin() );
         }
 
-            team_to_oric_m = modelEqConstraint.team_eq_constraint_to_oric_update(extrinsic_output_department, reward_team);
+            team_to_oric_m = modelEqConstraint.team_messages_to_oric(extrinsic_output_department, reward_team);
 
             fstream file_output("../ut_results/team_to_oric_m_wrapper", ios::out | ios::binary | ios:: trunc);
                 if (file_output.is_open()) {
@@ -74,8 +74,8 @@ void ut_eq_constraint_kc_mwm(string& ut_name){
         for (int project_index=0; project_index<N_PROJECTS; project_index++){
             copy ( project_to_eq_constraint_m_pure + N_TEAMS*project_index, project_to_eq_constraint_m_pure + N_TEAMS*(project_index+1), project_to_eq_constraint_m[project_index].begin() );
         }
-    
-    modelEqConstraint.project_eq_constraint_to_oric_update(project_to_eq_constraint_m, eq_constraint_to_oric_m, reward_project);
+
+        modelEqConstraint.project_messages_to_oric(project_to_eq_constraint_m, eq_constraint_to_oric_m, reward_project);
 
     fstream file_output("../ut_results/eq_constraint_to_oric_m_wrapper", ios::out | ios::binary | ios:: trunc);
         if (file_output.is_open()) {
@@ -149,7 +149,7 @@ void ut_equality_constraint_tsp(string& ut_name){
         
         vector<vector<impalib_type>> edge_ec_to_degree_constraint_m(N_EDGE_VARIABLES, vector<impalib_type>(N_NODES, zero_value));
 
-        modelEqualityConstraint.edge_ec_to_degree_constraint_relaxed_graph_update(edge_connections, edge_degree_constraint_cost, degree_constraint_to_eq_constraint_m, edge_ec_to_degree_constraint_m);
+        modelEqualityConstraint.messages_to_degree_relaxed(edge_connections, edge_degree_constraint_cost, degree_constraint_to_eq_constraint_m, edge_ec_to_degree_constraint_m);
         
         fstream file_output("../ut_results/edge_ec_to_degree_constraint_m_wrapper", ios::out | ios::binary | ios:: trunc);
             if (file_output.is_open()) {
@@ -194,7 +194,8 @@ void ut_equality_constraint_tsp(string& ut_name){
 
         vector<vector<impalib_type>> edge_ec_to_subtour_constraints_m(N_SUBTOURS, vector<impalib_type>(N_EDGE_VARIABLES, zero_value));
 
-        edge_ec_to_subtour_constraints_m = modelEqualityConstraint.edge_ec_to_subtour_constraints_update(delta_S_indices_list, cost_edge_variable, degree_constraint_to_eq_constraint_m, subtour_constraints_to_edge_ec_m, edge_connections);
+        edge_ec_to_subtour_constraints_m =
+            modelEqualityConstraint.messages_to_subtour(delta_S_indices_list, cost_edge_variable, degree_constraint_to_eq_constraint_m, subtour_constraints_to_edge_ec_m, edge_connections);
         
         fstream file_output("../ut_results/edge_ec_to_subtour_constraints_m_wrapper", ios::out | ios::binary | ios:: trunc);
             if (file_output.is_open()) {
@@ -219,7 +220,8 @@ void ut_equality_constraint_tsp(string& ut_name){
 
         vector<vector<impalib_type>> edge_ec_to_degree_constraint_m(N_EDGE_VARIABLES, vector<impalib_type>(N_NODES, zero_value));
 
-        modelEqualityConstraint.edge_ec_to_degree_constraint_augmented_graph_update(degree_constraint_to_eq_constraint_m, subtour_constraints_to_edge_ec_m, edge_connections, edge_degree_constraint_cost, edge_ec_to_degree_constraint_m);
+        modelEqualityConstraint.messages_to_degree_augmented(degree_constraint_to_eq_constraint_m, subtour_constraints_to_edge_ec_m, edge_connections, edge_degree_constraint_cost,
+                                                             edge_ec_to_degree_constraint_m);
         
         fstream file_output("../ut_results/edge_ec_to_degree_constraint_m_wrapper", ios::out | ios::binary | ios:: trunc);
             if (file_output.is_open()) {

--- a/test/include/ut_update_equality_constraint.hpp
+++ b/test/include/ut_update_equality_constraint.hpp
@@ -64,9 +64,6 @@ void ut_eq_constraint_kc_mwm(string& ut_name){
     }
 
     else if (ut_name == "ProjectEqConst2OricUpdate"){
-        
-        vector<vector<impalib_type>> eq_constraint_to_oric_m(N_PROJECTS, vector<impalib_type>(N_TEAMS, zero_value));
-        
         cnpy::NpyArray input5 = cnpy::npy_load("../ut_inputs/project_to_eq_constraint_m_pure.npy");
         impalib_type* project_to_eq_constraint_m_pure = input5.data<impalib_type>();
         vector<vector<impalib_type>> project_to_eq_constraint_m(N_PROJECTS, vector<impalib_type>(N_TEAMS, zero_value));
@@ -75,7 +72,7 @@ void ut_eq_constraint_kc_mwm(string& ut_name){
             copy ( project_to_eq_constraint_m_pure + N_TEAMS*project_index, project_to_eq_constraint_m_pure + N_TEAMS*(project_index+1), project_to_eq_constraint_m[project_index].begin() );
         }
 
-        modelEqConstraint.project_messages_to_oric(project_to_eq_constraint_m, eq_constraint_to_oric_m, reward_project);
+        auto eq_constraint_to_oric_m = modelEqConstraint.project_messages_to_oric(project_to_eq_constraint_m, reward_project);
 
     fstream file_output("../ut_results/eq_constraint_to_oric_m_wrapper", ios::out | ios::binary | ios:: trunc);
         if (file_output.is_open()) {

--- a/test/include/ut_update_or_inequality_constraint.hpp
+++ b/test/include/ut_update_or_inequality_constraint.hpp
@@ -43,7 +43,7 @@ void ut_oric(string& ut_name){
     }
 
     if (ut_name == "Oric2TeamUpdate"){
-        auto oric_to_team_m = modelOric.oric_to_team_update(eq_constraint_to_oric_m);
+        auto oric_to_team_m = modelOric.messages_to_team_eq(eq_constraint_to_oric_m);
 
         fstream file_output1("../ut_results/oric_to_team_m_wrapper", ios::out | ios::binary | ios:: trunc);
             if (file_output1.is_open()) {
@@ -62,9 +62,9 @@ void ut_oric(string& ut_name){
         copy ( team_to_oric_m_pure, team_to_oric_m_pure + N_TEAMS, team_to_oric_m.begin() );
 
         vector<vector<impalib_type>> oric_to_eq_constraint_m(N_PROJECTS, vector<impalib_type>(N_TEAMS, zero_value));
-        vector<vector<impalib_type>> eq_constraint_to_project_m(N_PROJECTS, vector<impalib_type>(N_TEAMS, zero_value));   
-        
-        modelOric.oric_to_project_eq_constraint_update(eq_constraint_to_oric_m, team_to_oric_m, oric_to_eq_constraint_m, eq_constraint_to_project_m, reward_project);
+        vector<vector<impalib_type>> eq_constraint_to_project_m(N_PROJECTS, vector<impalib_type>(N_TEAMS, zero_value));
+
+        modelOric.messages_to_project_eq(eq_constraint_to_oric_m, team_to_oric_m, oric_to_eq_constraint_m, eq_constraint_to_project_m, reward_project);
 
             fstream file_output2("../ut_results/oric_to_eq_constraint_m_wrapper", ios::out | ios::binary | ios:: trunc);
             if (file_output2.is_open()) {

--- a/test/include/ut_update_or_inequality_constraint.hpp
+++ b/test/include/ut_update_or_inequality_constraint.hpp
@@ -43,9 +43,7 @@ void ut_oric(string& ut_name){
     }
 
     if (ut_name == "Oric2TeamUpdate"){
-        vector<impalib_type> oric_to_team_m(N_TEAMS, zero_value);
-
-        modelOric.oric_to_team_update(eq_constraint_to_oric_m, oric_to_team_m);
+        auto oric_to_team_m = modelOric.oric_to_team_update(eq_constraint_to_oric_m);
 
         fstream file_output1("../ut_results/oric_to_team_m_wrapper", ios::out | ios::binary | ios:: trunc);
             if (file_output1.is_open()) {


### PR DESCRIPTION
## Context 
This PR was made with a couple goals in mind: to

1. Simplify unnecessary programming constructs (overly verbose naming, comments)
2. Streamline class API details

We highlight a few representative changes below. 

### Overly verbose variable/function naming
For example, 

- `OutputsKcMwm::intrinsic_out_mwm_update` was renamed to `OutputsKcMwm::update_intrinsic`. 
- `OutputsKcMwm::extrinsic_output_team_update` was renamed to `OutputsKcMwm::update_extrinsic`.

This simplifies usage, as well as groups similar methods under a common `update_` naming prefix.  

### Redundant commenting 
In some cases, code commenting was unnecessary. Consider the following example: 

```cpp
// Reserve memory for vectors based on provided sizes
TeamsWeightsPerDepartment.reserve(numDepartments_);
```

The inline comment here is clear provided the user knows what `vector::reserve` does. 

### Unnecessary `private` class state
Philosophically, `private` fields should be used to extract data that is needed for multiple member functions to perform their tasks. However, in many cases existing `private` fields were being used to store data being written and accessed by a single member function. In this case, it is probably more appropriate to use function arguments and return values. 

Consider `Knapsack::extrinsic_output_department_lhs`. This originally had the signature 

```cpp
void extrinsic_output_department_lhs(vector<vector<int>> &, vector<vector<impalib_type>> &,
                                         vector<vector<impalib_type>> &, int, vector<vector<impalib_type>> &, int,
                                         vector<vector<impalib_type>> &); ///< extrinsic output of department constraint
```

where the final parameter was used as an output parameter to the private member field `extrinsicOutputDepartmentDummy_`. We removed that variable and changed the signature as follows: 

```cpp
vector<impalib_type> extrinsic_output_department_lhs(vector<int> &, vector<vector<impalib_type>> &,
                                         vector<vector<impalib_type>> &, int, vector<vector<impalib_type>> &, int); ///< extrinsic output of department constraint
```

At the call site, 

```cpp
knapsack.extrinsic_output_department_lhs(/* args */)
``` 

is replaced with 

```cpp
auto out = knapsack.extrinsic_output_department_lhs(/* args */)
```

## Future Work 
Currently this PR has conflicts with `main`.  Arguably some changes (such as da556c8) should not have been made as such: one can imagine the application-specific instances of e.g. `EqualityConstraint` inheriting from a common interface rather than being aggregated into a single class. This will be an ongoing discussion/refactoring effort.

