### PR TITLE
Simple non-breaking improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,7 @@
 cmake_minimum_required(VERSION 3.18...3.22)
 
 project(impalib VERSION "0.1.0" LANGUAGES CXX)
-
-#add_compile_options(-std=c++11) #added for Mac recognition
+set(CMAKE_CXX_STANDARD 11)
 
 include(GNUInstallDirs)
 

--- a/include/impalib/graphical_model.hpp
+++ b/include/impalib/graphical_model.hpp
@@ -56,20 +56,6 @@ class GraphicalModelKcMwm {
  * @param[in] N_ITERATIONS: number of iterations for running IMPA
  * @param[in] FILT_FLAG: filtering on or off
  * @param[in] ALPHA: filtering parameter value (between 0 and 1)
- * @param[out] modelInputs_: object of type InputsKcMwm: inputs of graphical
- * model
- * @param[out] outputs: object of type OutputsKcMwm: outputs of graphical model
- * @param[out] projectIneqConstraint_: object of type InequalityConstraint:
- * object associated with inequality constraint operations
- * @param[out] modelEqConstraint_: object of type EqualityConstraintKcMwm:
- * object associated with equality constraint operations
- * @param[out] numProjects_: N_PROJECTS
- * @param[out] numTeams_: N_TEAMS
- * @param[out] numDepartments_: N_DEPARTMENTS
- * @param[out] maxSizeNonZeroWeights_: MAX_SIZE_NON_ZERO_WEIGHTS
- * @param[out] numIterations_: N_ITERATIONS
- * @param[out] filteringFlag_: FILT_FLAG
- * @param[out] alpha_: ALPHA
  *
  */
 
@@ -256,26 +242,6 @@ class GraphicalModelTsp {
  * @param[in] ALPHA: filtering parameter value (between 0 and 1)
  * @param[in] THRESHOLD: threshold for hard decision on intrinsic messages
  * @param[in] MAX_COUNT: maximum count of failure cases before exiting the code
- * @param[out] modelDegreeConstraint_: object of type DegreeConstraint: object
- * associated with degree constraint operations
- * @param[out] modelEqConstraint_: object of type EqualityConstraintTsp: object
- * associated with equality constraint operations
- * @param[out] modelSubtourEliminationConstraint_: object of type
- * SubtourEliminationConstraint: object associated with subtour elimination
- * constraint operations
- * @param[out] modelInputs_: object of type InputsTsp: object associated with
- * inputs of tsp
- * @param[out] outputs: object of type OutputsTsp: object associated with
- * outputs of tsp
- * @param[out] numIterations_: NUM_ITERATIONS
- * @param[out] filteringFlag_: FILTERING_FLAG
- * @param[out] alpha_: ALPHA
- * @param[out] numNodes_: NUM_NODES
- * @param[out] augmentationFlag_: AUGMENTATION_FLAG
- * @param[out] resetFlag_: RESET_FLAG
- * @param[out] numEdgeVariables_: NUM_EDGE_VARIABLES
- * @param[out] threshold_: THRESHOLD
- * @param[out] maxCount_: MAX_COUNT
  *
  */
 
@@ -742,9 +708,9 @@ void GraphicalModelTsp::subtour_elimination_constraints_analysis(unordered_map<i
  * @return new_loops_list: list of detected loops in rGraph
  *
  */
-vector<vector<int>> GraphicalModelTsp::get_closed_loops(unordered_map<int, vector<int>> &rGraph, vector<vector<int>> &rSelectedEgdes) {
+vector<vector<int>> GraphicalModelTsp::get_closed_loops(unordered_map<int, vector<int>> &rGraph, vector<vector<int>> &rSelectedEdges) {
     // Update the graph based on selected edges
-    for (const auto &connection : rSelectedEgdes) {
+    for (const auto &connection : rSelectedEdges) {
         if (rGraph.find(connection[0]) != rGraph.end()) {
             rGraph[connection[0]].push_back(connection[1]);
         } else {
@@ -924,17 +890,6 @@ class GraphicalModelKsat {
  * @param[in] FILTERING_FLAG: filtering on or off
  * @param[in] ALPHA: filtering parameter value (between 0 and 1)
  * @param[in] NUM_USED_VARIABLES: number of variables used to construct the formula
- * @param[out] modelInputs_: object of type InputsKsat
- * @param[out] modelEqConstraint_: object of type EqualityConstraint
- * @param[out] modelKsatConstraint_: object of type KsatConstraint
- * @param[out] outputs: object of type OutputsKsat
- * @param[out] numIterations_: N_ITERATIONS
- * @param[out] numVariables_: NUM_VARIABLES
- * @param[out] numConstraints_: NUM_CONSTRAINTS
- * @param[out] kVariable_: K_VARIABLE
- * @param[out] filteringFlag_: FILTERING_FLAG
- * @param[out] alpha_: ALPHA
- * @param[out] numUsedVariables_: NUM_USED_VARIABLES
  *
  */
 

--- a/include/impalib/graphical_model.hpp
+++ b/include/impalib/graphical_model.hpp
@@ -100,8 +100,6 @@ GraphicalModelKcMwm::GraphicalModelKcMwm(const int N_DEPARTMENTS, const int N_TE
     eqConstraint2ProjectM_.reserve(numProjects_);
     project2EqConstraintM_.reserve(numProjects_);
 
-    /// initializes and populates nested vectors for mapping relationships
-    /// between constraints, teams, and projects
     for (int project_index = 0; project_index < numProjects_; project_index++) {
         eqConstraint2OricM_.push_back(vector<impalib_type>(numTeams_, zero_value));
         oric2EqConstraintM_.push_back(vector<impalib_type>(numTeams_, zero_value));
@@ -156,56 +154,33 @@ void GraphicalModelKcMwm::initialize(const impalib_type *pREWARD_TEAM_PY, impali
  */
 
 void GraphicalModelKcMwm::iterate(const int *pNON_ZERO_WEIGHT_INDICES_SIZES_PY) {
-    // Iterate over each iteration
     for (int iter = 0; iter < numIterations_; iter++) {
-        // Iterate over each department
         for (int department_index = 0; department_index < numDepartments_; department_index++) {
-            // Retrieve maximum state (capacity) for the department
             int max_state_department = modelInputs_.MaxState[department_index];
 
             // Initialize forward and backward message vectors
             vector<vector<impalib_type>> stage_forward_messages(numTeams_ + 1, vector<impalib_type>(max_state_department + 1, zero_value));
             vector<vector<impalib_type>> stage_backward_messages(numTeams_ + 1, vector<impalib_type>(max_state_department + 1, zero_value));
 
-            // Perform forward pass for knapsacks
             modelKnapsacks_.forward(department_index, stage_forward_messages, max_state_department, modelInputs_.NonZeroWeightIndices, pNON_ZERO_WEIGHT_INDICES_SIZES_PY,
                                     modelInputs_.TeamsWeightsPerDepartment, modelInputs_.Team2KnapsackM);
-
-            // Perform backward pass for knapsacks
             modelKnapsacks_.backward(department_index, stage_backward_messages, max_state_department, modelInputs_.NonZeroWeightIndices, pNON_ZERO_WEIGHT_INDICES_SIZES_PY,
                                      modelInputs_.TeamsWeightsPerDepartment, modelInputs_.Team2KnapsackM);
 
-            // Compute extrinsic output for the department
             modelKnapsacks_.extrinsic_output_department_lhs(modelInputs_.TeamsWeightsPerDepartment, stage_forward_messages, modelInputs_.Team2KnapsackM, department_index, stage_backward_messages,
                                                             max_state_department, extrinsicOutputDepartmentDummy_);
-
-            // Process extrinsic output for the department
             modelKnapsacks_.process_extrinsic_output_department(department_index, iter, extrinsicOutputDepartmentDummy_, extrinsicOutputDepartment_);
         }
 
-        // Update messages from teams equality constraints to ORIC
         modelEqConstraint_.team_eq_constraint_to_oric_update(extrinsicOutputDepartment_, team2OricM_, modelInputs_.RewardTeam);
-
-        // Update messages from ORIC to project equality constraints
         modelOric_.oric_to_project_eq_constraint_update(eqConstraint2OricM_, team2OricM_, oric2EqConstraintM_, eqConstraint2ProjectM_, modelInputs_.RewardProject);
-
-        // Update messages from project inequality constraints to project
-        // equality constraints
         projectIneqConstraint_.project_inequality_constraint_update(eqConstraint2ProjectM_, project2EqConstraintM_);
-
-        // Update messages from project equality constraints to ORIC
         modelEqConstraint_.project_eq_constraint_to_oric_update(project2EqConstraintM_, eqConstraint2OricM_, modelInputs_.RewardProject);
 
-        // Update messages from ORIC to teams equality constraints
         modelOric_.oric_to_team_update(eqConstraint2OricM_, oric2PackageM_);
-
-        // Update intrinsic outputs for teams
         outputs.intrinsic_out_mwm_update(oric2EqConstraintM_, project2EqConstraintM_, modelInputs_.RewardProject);
-
-        // Update messages from teams to knapsack constraints
         modelKnapsacks_.team_to_knapsack_update(modelInputs_.NonZeroWeightIndices, modelInputs_.Team2KnapsackM, modelInputs_.RewardTeam, extrinsicOutputDepartment_, oric2PackageM_);
     }
-    // Update extrinsic output messages for teams
     outputs.extrinsic_output_team_update(extrinsicOutputDepartment_, oric2PackageM_);
 }
 
@@ -320,7 +295,6 @@ GraphicalModelTsp::GraphicalModelTsp(const int NUM_ITERATIONS, const int NUM_NOD
       numEdgeVariables_(NUM_EDGE_VARIABLES),
       threshold_(THRESHOLD),
       maxCount_(MAX_COUNT) {
-    // Reserve memory for messages
     DegreeConstraint2EqConstraintDummyM_.reserve(numEdgeVariables_);
     DegreeConstraint2EqConstraintM_.reserve(numEdgeVariables_);
 
@@ -330,7 +304,6 @@ GraphicalModelTsp::GraphicalModelTsp(const int NUM_ITERATIONS, const int NUM_NOD
         DegreeConstraint2EqConstraintM_.push_back(vector<impalib_type>(numNodes_, zero_value));
     }
 
-    // Initialize counters and flags
     numAugmentations_ = 0;
     costImpa_ = zero_value;
     noConsClosedLoopsCount_ = 0;
@@ -363,7 +336,7 @@ GraphicalModelTsp::GraphicalModelTsp(const int NUM_ITERATIONS, const int NUM_NOD
 
 void GraphicalModelTsp::initialize(const int *pEDGE_CONNECTIONS_PY, const impalib_type *pCOST_EDGE_VARIABLE_PY, const impalib_type *pCOST_MATRIX_PY, impalib_type *pEdge_ec_to_degree_constraint_m_py,
                                    const impalib_type *pEDGE_DEGREE_CONSTRAINT_COST_PY) {
-    // Process inputs to populate model data
+    // Populate model data
     modelInputs_.process_inputs(pEDGE_CONNECTIONS_PY, pCOST_EDGE_VARIABLE_PY, pCOST_MATRIX_PY, pEdge_ec_to_degree_constraint_m_py, pEDGE_DEGREE_CONSTRAINT_COST_PY);
 }
 
@@ -375,26 +348,13 @@ void GraphicalModelTsp::initialize(const int *pEDGE_CONNECTIONS_PY, const impali
  *
  */
 void GraphicalModelTsp::iterate_relaxed_graph() {
-    // Perform iterations
     for (int iter = 0; iter < numIterations_; iter++) {
-        // Update degree constraint to edge equality constraint messages
         modelDegreeConstraint_.degree_constraint_to_edge_ec_update(modelInputs_.EdgeEc2DegreeConstraintM, modelInputs_.EdgeConnections, DegreeConstraint2EqConstraintDummyM_);
-
-        // Perform filtering process on messages from degree constraints to
-        // equality constraints
         modelDegreeConstraint_.process_filtering(iter, DegreeConstraint2EqConstraintDummyM_, DegreeConstraint2EqConstraintM_);
-
-        // Update edge equality constraint to degree constraint messages for the
-        // relaxed graph
         modelEqConstraint_.edge_ec_to_degree_constraint_relaxed_graph_update(modelInputs_.EdgeConnections, modelInputs_.EdgeDegreeConstraintCost, DegreeConstraint2EqConstraintM_,
                                                                              modelInputs_.EdgeEc2DegreeConstraintM);
     }
-
-    // Update extrinsic output for edge equality constraints in the relaxed
-    // graph
     outputs.extrinsic_output_edge_ec_relaxed_graph_update(DegreeConstraint2EqConstraintM_);
-
-    // Update intrinsic output for edge equality constraints
     outputs.intrinsic_output_edge_ec_update(modelInputs_.CostEdgeVariable);
 
     // Perform hard decision analysis to select edges
@@ -403,11 +363,8 @@ void GraphicalModelTsp::iterate_relaxed_graph() {
 
     // Initialize graph for subtour elimination constraints analysis
     unordered_map<int, vector<int>> graph;
-
-    // Analyze subtour elimination constraints
     subtour_elimination_constraints_analysis(graph, selected_edges);
 
-    // Update selected edges
     selectedEdges_ = selected_edges;
 }
 
@@ -429,26 +386,22 @@ void GraphicalModelTsp::perform_augmentation(const int MAX_AUGM_COUNT) {
         subtourConstraints2EdgeEcDummyM_ = subtourConstraints2EdgeEcM_;
     }
 
-    // Continue augmentation until certain flags are set
+    // Continue augmentation
     while (!subtourConstraintsSatisfiedFlag && augmentationFlag_ && !tourImpaFlag_) {
-        // Check for failure flags
         if (noConsClosedLoopsCountExcFlag_ || noImprovSolCountExcFlag_ || solOscCountExcFlag_) {
             cout << "noConsClosedLoopsCountExcFlag_: " << noConsClosedLoopsCountExcFlag_ << '\n';
             cout << "noImprovSolCountExcFlag_: " << noImprovSolCountExcFlag_ << '\n';
             cout << "solOscCountExcFlag_: " << solOscCountExcFlag_ << '\n';
             break;
         }
-        // Check for zero cost
         if (costImpa_ == zero_value) {
             cout << "Cost is zero" << '\n';
             cout << "Possibly Nan" << '\n';
             exit(0);
         }
 
-        // Iterate over the augmented graph
         iterate_augmented_graph();
 
-        // Check if maximum augmentation count reached
         if (numAugmentations_ == MAX_AUGM_COUNT) {
             cout << "MAX_AUGM_COUNT reached" << '\n';
             break;
@@ -494,19 +447,12 @@ void GraphicalModelTsp::process_ouputs(impalib_type *pExtrinsic_output_edge_ec, 
                                        int *pSubtour_paths, int *pSubtour_paths_size) {
     // Copy extrinsic output for edge equality constraints
     copy(outputs.ExtrinsicOutputEdgeEc.begin(), outputs.ExtrinsicOutputEdgeEc.begin() + numEdgeVariables_, pExtrinsic_output_edge_ec);
-
-    // Copy number of augmentations
     *pNum_augmentations = numAugmentations_;
-
-    // Copy number of added constraints
     *pNum_added_constraints = static_cast<int>(subtourConstraints2EdgeEcM_.size());
 
-    // Copy tour results
     copy(tourImpa_.begin(), tourImpa_.begin() + static_cast<int>(tourImpa_.size()), pTour_impa);
-
-    // Copy cost of tour
     *pCost_impa = costImpa_;
-    // Copy failure flags
+
     *pNo_improv_sol_count_exc_flag = noImprovSolCountExcFlag_;
     *pNo_cons_loops_count_exc_flag = noConsClosedLoopsCountExcFlag_;
     *pSol_osc_count_exc_flag = solOscCountExcFlag_;
@@ -561,28 +507,14 @@ void GraphicalModelTsp::iterate_augmented_graph() {
         modelSubtourEliminationConstraint_.subtourConstraints2EdgeEcOld_.push_back(vector<impalib_type>(numEdgeVariables_, zero_value));
     }
 
-    // Perform iterations over the augmented graph
     for (int iter = 0; iter < numIterations_; iter++) {
-        // Update messages from degree constraint to edge equality constraint
         modelDegreeConstraint_.degree_constraint_to_edge_ec_update(modelInputs_.EdgeEc2DegreeConstraintM, modelInputs_.EdgeConnections, DegreeConstraint2EqConstraintDummyM_);
-
-        // Perform filtering process on messages from degree constraints to
-        // equality constraints
         modelDegreeConstraint_.process_filtering(iter, DegreeConstraint2EqConstraintDummyM_, DegreeConstraint2EqConstraintM_);
 
-        // Update messages from edge equality constraint to subtour constraints
         edgeEc2SubtourConstraintsM_ = modelEqConstraint_.edge_ec_to_subtour_constraints_update(delta_S_indices_list, modelInputs_.CostEdgeVariable, DegreeConstraint2EqConstraintM_,
                                                                                                subtourConstraints2EdgeEcM_, modelInputs_.EdgeConnections);
-
-        // Update messages from edge subtour elimination constraints to subtour
-        // constraints
         modelSubtourEliminationConstraint_.subtour_constraints_to_edge_ec_update(edgeEc2SubtourConstraintsM_, delta_S_indices_list, subtourConstraints2EdgeEcDummyM_);
-
-        // Perform filtering process on messages from subtour elimination
-        // constraints to edge equality constraints
         modelSubtourEliminationConstraint_.process_filtering(iter, subtourConstraints2EdgeEcDummyM_, subtourConstraints2EdgeEcM_, delta_S_indices_list);
-
-        // Update messages from edge equality constraint to degree constraint
         modelEqConstraint_.edge_ec_to_degree_constraint_augmented_graph_update(DegreeConstraint2EqConstraintM_, subtourConstraints2EdgeEcM_, modelInputs_.EdgeConnections,
                                                                                modelInputs_.EdgeDegreeConstraintCost, modelInputs_.EdgeEc2DegreeConstraintM);
     }
@@ -597,27 +529,19 @@ void GraphicalModelTsp::iterate_augmented_graph() {
         }
     }
 
-    // Exit if NaN is detected
     if (flag_nan) {
         cout << "NaN detected" << '\n';
         exit(0);
     }
 
-    // Update extrinsic output for edge equality constraints in the augmented
-    // graph
     outputs.extrinsic_output_edge_ec_augmented_graph_update(DegreeConstraint2EqConstraintM_, subtourConstraints2EdgeEcM_);
-
-    // Update intrinsic output for edge equality constraints
     outputs.intrinsic_output_edge_ec_update(modelInputs_.CostEdgeVariable);
 
-    // Clear selected edges
     selectedEdges_.clear();
     vector<vector<int>> selected_edges;
-
-    // Perform hard decision analysis to select edges
     hard_decision_analysis(selected_edges);
 
-    // Check for solution improvement or not
+    // Check for solution improvement
     if (!selected_edges_old_.empty()) {
         bool areEqual = (selected_edges == selected_edges_old_);
         if (areEqual) {
@@ -649,18 +573,12 @@ void GraphicalModelTsp::iterate_augmented_graph() {
         }
     }
 
-    // Update old selected edges
     if (!selected_edges_old_.empty()) {
         selected_edges_old_old_ = selected_edges_old_;
     }
-
-    // Update selected edges and perform subtour elimination constraints
-    // analysis
     selected_edges_old_ = selected_edges;
     selectedEdges_ = selected_edges;
-
     unordered_map<int, vector<int>> graph;
-
     subtour_elimination_constraints_analysis(graph, selected_edges);
 }
 
@@ -671,7 +589,6 @@ void GraphicalModelTsp::iterate_augmented_graph() {
  *
  */
 void GraphicalModelTsp::hard_decision_analysis(vector<vector<int>> &rSelectedEdges) {
-    // Initialize hard decision vector
     hard_decision.resize(numEdgeVariables_);
     fill(hard_decision.begin(), hard_decision.begin() + numEdgeVariables_, numeric_limits<int>::max());
 
@@ -734,7 +651,6 @@ void GraphicalModelTsp::hard_decision_analysis(vector<vector<int>> &rSelectedEdg
  */
 
 void GraphicalModelTsp::subtour_elimination_constraints_analysis(unordered_map<int, vector<int>> &rGraph, vector<vector<int>> &rSelectedEdges) {
-    // Clear previous closed paths sizes
     closedPathsSize_.clear();  // just store it at the end if applicable
 
     // Get closed loops from the graph
@@ -742,7 +658,6 @@ void GraphicalModelTsp::subtour_elimination_constraints_analysis(unordered_map<i
     subtourPaths_.clear();
     subtourPaths_ = loops_list;
 
-    // If no loops found
     if (loops_list.empty()) {
         cout << "Exited: Cannot find tours using get_closed_loops()" << '\n';
         noConsClosedLoopsCount_ += 1;
@@ -753,7 +668,7 @@ void GraphicalModelTsp::subtour_elimination_constraints_analysis(unordered_map<i
             noConsClosedLoopsCountExcFlag_ = true;
         }
     }
-    // If a single tour is found
+
     else if (loops_list.size() == 1 && loops_list[0].size() == numNodes_) {
         tourImpaFlag_ = true;
         subtourConstraintsSatisfiedFlag = true;
@@ -837,11 +752,9 @@ vector<vector<int>> GraphicalModelTsp::get_closed_loops(unordered_map<int, vecto
         }
     }
 
-    // Initialize variables to store loops
     vector<vector<int>> loops_list;
     vector<int> visited_nodes;
 
-    // Iterate over graph connections
     for (const auto &connection : rGraph) {
         int start_node = connection.first;
         const vector<int> &end_nodes = connection.second;
@@ -849,15 +762,11 @@ vector<vector<int>> GraphicalModelTsp::get_closed_loops(unordered_map<int, vecto
         if (find(visited_nodes.begin(), visited_nodes.end(), start_node) != visited_nodes.end()) {
             continue;
         } else {
-            // Iterate over end nodes
             for (int j = 0; j < end_nodes.size(); j++) {
                 unordered_set<int> visited_set;
                 vector<int> path;
 
-                // Find closed loop starting from current node
                 vector<int> closed_loop = find_closed_loop(rGraph, start_node, end_nodes[j], visited_set, path, visited_nodes);
-
-                // Add closed loop if found
                 if (!closed_loop.empty()) {
                     loops_list.push_back(closed_loop);
                 }
@@ -922,7 +831,6 @@ vector<vector<int>> GraphicalModelTsp::get_closed_loops(unordered_map<int, vecto
  *
  */
 bool GraphicalModelTsp::isSubsequence(const vector<int> &seq, const vector<int> &subseq, int j) {
-    // Check if subsequence exists in a sequence
     for (int i = 0; i < static_cast<int>(seq.size() - subseq.size()); ++i) {
         if (equal(seq.begin() + i, seq.begin() + i + static_cast<int>(subseq.size()), subseq.begin())) {
             return true;
@@ -965,7 +873,6 @@ vector<int> GraphicalModelTsp::find_closed_loop(unordered_map<int, vector<int>> 
         return vector<int>();
     }
 
-    // Iterate over connections
     for (int node : rGraph.at(current)) {
         // If node is not visited, continue search
         if (visited.find(node) == visited.end()) {

--- a/include/impalib/graphical_model.hpp
+++ b/include/impalib/graphical_model.hpp
@@ -59,7 +59,7 @@ class GraphicalModelKcMwm {
  *
  */
 
-GraphicalModelKcMwm::GraphicalModelKcMwm(const int N_DEPARTMENTS, const int N_TEAMS, const int N_PROJECTS, const int MAX_SIZE_NON_ZERO_WEIGHTS, const int N_ITERATIONS, const bool FILT_FLAG,
+inline GraphicalModelKcMwm::GraphicalModelKcMwm(const int N_DEPARTMENTS, const int N_TEAMS, const int N_PROJECTS, const int MAX_SIZE_NON_ZERO_WEIGHTS, const int N_ITERATIONS, const bool FILT_FLAG,
                                          const impalib_type ALPHA)
     : modelInputs_(N_DEPARTMENTS, N_TEAMS, N_PROJECTS, MAX_SIZE_NON_ZERO_WEIGHTS),
       outputs(N_DEPARTMENTS, N_TEAMS, N_PROJECTS),
@@ -122,7 +122,7 @@ GraphicalModelKcMwm::GraphicalModelKcMwm(const int N_DEPARTMENTS, const int N_TE
  *
  */
 
-void GraphicalModelKcMwm::initialize(const impalib_type *pREWARD_TEAM_PY, impalib_type *pTransition_model_py, const int *pITEMS_WEIGHTS_PER_DEPARTMENT_PY, const int *pNON_ZERO_WEIGHT_INDICES_SIZES_PY,
+inline void GraphicalModelKcMwm::initialize(const impalib_type *pREWARD_TEAM_PY, impalib_type *pTransition_model_py, const int *pITEMS_WEIGHTS_PER_DEPARTMENT_PY, const int *pNON_ZERO_WEIGHT_INDICES_SIZES_PY,
                                      const int *p_NON_ZERO_WEIGHT_INDICES_PY, const impalib_type *pREWARD_PROJECT_PY, const int *pMAX_STATE_PY) {
     /// calls a method process_inputs() on an object modelInputs_, passing
     /// several pointers to Python objects as arguments
@@ -139,7 +139,7 @@ void GraphicalModelKcMwm::initialize(const impalib_type *pREWARD_TEAM_PY, impali
  *
  */
 
-void GraphicalModelKcMwm::iterate(const int *pNON_ZERO_WEIGHT_INDICES_SIZES_PY) {
+inline void GraphicalModelKcMwm::iterate(const int *pNON_ZERO_WEIGHT_INDICES_SIZES_PY) {
     for (int iter = 0; iter < numIterations_; iter++) {
         for (int department_index = 0; department_index < numDepartments_; department_index++) {
             int max_state_department = modelInputs_.MaxState[department_index];
@@ -245,7 +245,7 @@ class GraphicalModelTsp {
  *
  */
 
-GraphicalModelTsp::GraphicalModelTsp(const int NUM_ITERATIONS, const int NUM_NODES, const int NUM_EDGE_VARIABLES, const bool AUGMENTATION_FLAG, const bool RESET_FLAG, const bool FILTERING_FLAG,
+inline GraphicalModelTsp::GraphicalModelTsp(const int NUM_ITERATIONS, const int NUM_NODES, const int NUM_EDGE_VARIABLES, const bool AUGMENTATION_FLAG, const bool RESET_FLAG, const bool FILTERING_FLAG,
                                      const impalib_type ALPHA, const impalib_type THRESHOLD, const int MAX_COUNT)
     : modelDegreeConstraint_(NUM_NODES, NUM_EDGE_VARIABLES, FILTERING_FLAG, ALPHA),
       modelEqConstraint_(NUM_NODES, NUM_EDGE_VARIABLES, FILTERING_FLAG, ALPHA),
@@ -300,7 +300,7 @@ GraphicalModelTsp::GraphicalModelTsp(const int NUM_ITERATIONS, const int NUM_NOD
  *
  */
 
-void GraphicalModelTsp::initialize(const int *pEDGE_CONNECTIONS_PY, const impalib_type *pCOST_EDGE_VARIABLE_PY, const impalib_type *pCOST_MATRIX_PY, impalib_type *pEdge_ec_to_degree_constraint_m_py,
+inline void GraphicalModelTsp::initialize(const int *pEDGE_CONNECTIONS_PY, const impalib_type *pCOST_EDGE_VARIABLE_PY, const impalib_type *pCOST_MATRIX_PY, impalib_type *pEdge_ec_to_degree_constraint_m_py,
                                    const impalib_type *pEDGE_DEGREE_CONSTRAINT_COST_PY) {
     // Populate model data
     modelInputs_.process_inputs(pEDGE_CONNECTIONS_PY, pCOST_EDGE_VARIABLE_PY, pCOST_MATRIX_PY, pEdge_ec_to_degree_constraint_m_py, pEDGE_DEGREE_CONSTRAINT_COST_PY);
@@ -313,7 +313,7 @@ void GraphicalModelTsp::initialize(const int *pEDGE_CONNECTIONS_PY, const impali
  * constraints and edge equality constraints
  *
  */
-void GraphicalModelTsp::iterate_relaxed_graph() {
+inline void GraphicalModelTsp::iterate_relaxed_graph() {
     for (int iter = 0; iter < numIterations_; iter++) {
         modelDegreeConstraint_.degree_constraint_to_edge_ec_update(modelInputs_.EdgeEc2DegreeConstraintM, modelInputs_.EdgeConnections, DegreeConstraint2EqConstraintDummyM_);
         modelDegreeConstraint_.process_filtering(iter, DegreeConstraint2EqConstraintDummyM_, DegreeConstraint2EqConstraintM_);
@@ -344,7 +344,7 @@ void GraphicalModelTsp::iterate_relaxed_graph() {
  *
  */
 
-void GraphicalModelTsp::perform_augmentation(const int MAX_AUGM_COUNT) {
+inline void GraphicalModelTsp::perform_augmentation(const int MAX_AUGM_COUNT) {
     // Add empty vectors to subtour constraints if needed
     if (delta_S_indices_list.size() > 0) {
         vector<vector<impalib_type>> temp(delta_S_indices_list.size(), vector<impalib_type>(numEdgeVariables_, zero_value));
@@ -408,7 +408,7 @@ void GraphicalModelTsp::perform_augmentation(const int MAX_AUGM_COUNT) {
  *
  */
 
-void GraphicalModelTsp::process_ouputs(impalib_type *pExtrinsic_output_edge_ec, int *pNum_augmentations, int *pNum_added_constraints, int *pTour_impa, impalib_type *pCost_impa,
+inline void GraphicalModelTsp::process_ouputs(impalib_type *pExtrinsic_output_edge_ec, int *pNum_augmentations, int *pNum_added_constraints, int *pTour_impa, impalib_type *pCost_impa,
                                        bool *pNo_improv_sol_count_exc_flag, bool *pNo_cons_loops_count_exc_flag, bool *pSol_osc_count_exc_flag, int *pSelected_edges, int *pSelected_edges_size,
                                        int *pSubtour_paths, int *pSubtour_paths_size) {
     // Copy extrinsic output for edge equality constraints
@@ -445,7 +445,7 @@ void GraphicalModelTsp::process_ouputs(impalib_type *pExtrinsic_output_edge_ec, 
  * This function will run IMPA on augmented grahical model
  *
  */
-void GraphicalModelTsp::iterate_augmented_graph() {
+inline void GraphicalModelTsp::iterate_augmented_graph() {
     // Reset messages if flag is set
     if (resetFlag_) {
         for (size_t i = 0; i < modelInputs_.EdgeConnections.size(); i++) {
@@ -554,7 +554,7 @@ void GraphicalModelTsp::iterate_augmented_graph() {
  * @param[out] rSelectedEdges: activated edges after running IMPA
  *
  */
-void GraphicalModelTsp::hard_decision_analysis(vector<vector<int>> &rSelectedEdges) {
+inline void GraphicalModelTsp::hard_decision_analysis(vector<vector<int>> &rSelectedEdges) {
     hard_decision.resize(numEdgeVariables_);
     fill(hard_decision.begin(), hard_decision.begin() + numEdgeVariables_, numeric_limits<int>::max());
 
@@ -616,7 +616,7 @@ void GraphicalModelTsp::hard_decision_analysis(vector<vector<int>> &rSelectedEdg
  *
  */
 
-void GraphicalModelTsp::subtour_elimination_constraints_analysis(unordered_map<int, vector<int>> &rGraph, const vector<vector<int>> &rSelectedEdges) {
+inline void GraphicalModelTsp::subtour_elimination_constraints_analysis(unordered_map<int, vector<int>> &rGraph, const vector<vector<int>> &rSelectedEdges) {
     closedPathsSize_.clear();  // just store it at the end if applicable
 
     // Get closed loops from the graph
@@ -708,7 +708,7 @@ void GraphicalModelTsp::subtour_elimination_constraints_analysis(unordered_map<i
  * @return new_loops_list: list of detected loops in rGraph
  *
  */
-vector<vector<int>> GraphicalModelTsp::get_closed_loops(unordered_map<int, vector<int>> &rGraph, const vector<vector<int>> &rSelectedEdges) {
+inline vector<vector<int>> GraphicalModelTsp::get_closed_loops(unordered_map<int, vector<int>> &rGraph, const vector<vector<int>> &rSelectedEdges) {
     // Update the graph based on selected edges
     for (const auto &connection : rSelectedEdges) {
         if (rGraph.find(connection[0]) != rGraph.end()) {
@@ -796,7 +796,7 @@ vector<vector<int>> GraphicalModelTsp::get_closed_loops(unordered_map<int, vecto
  * @return false or true if subseq is a isSubsequence of seq
  *
  */
-bool GraphicalModelTsp::isSubsequence(const vector<int> &seq, const vector<int> &subseq, int j) {
+inline bool GraphicalModelTsp::isSubsequence(const vector<int> &seq, const vector<int> &subseq, int j) {
     for (int i = 0; i < static_cast<int>(seq.size() - subseq.size()); ++i) {
         if (equal(seq.begin() + i, seq.begin() + i + static_cast<int>(subseq.size()), subseq.begin())) {
             return true;
@@ -823,7 +823,7 @@ bool GraphicalModelTsp::isSubsequence(const vector<int> &seq, const vector<int> 
  * between the nodes (if a tour is found, )
  *
  */
-vector<int> GraphicalModelTsp::find_closed_loop(unordered_map<int, vector<int>> &rGraph, int start_node, int current, unordered_set<int> visited, vector<int> path, vector<int> &visited_nodes) {
+inline vector<int> GraphicalModelTsp::find_closed_loop(unordered_map<int, vector<int>> &rGraph, int start_node, int current, unordered_set<int> visited, vector<int> path, vector<int> &visited_nodes) {
     visited.insert(current);
     path.push_back(current);
 
@@ -893,7 +893,7 @@ class GraphicalModelKsat {
  *
  */
 
-GraphicalModelKsat::GraphicalModelKsat(int NUM_ITERATIONS, int NUM_VARIABLES, int NUM_CONSTRAINTS, int K_VARIABLE, bool FILTERING_FLAG, impalib_type ALPHA,
+inline GraphicalModelKsat::GraphicalModelKsat(int NUM_ITERATIONS, int NUM_VARIABLES, int NUM_CONSTRAINTS, int K_VARIABLE, bool FILTERING_FLAG, impalib_type ALPHA,
                                        int NUM_USED_VARIABLES)
     : modelInputs_(NUM_VARIABLES, NUM_CONSTRAINTS, K_VARIABLE, numUsedVariables_),
       modelEqConstraint_(NUM_VARIABLES, NUM_CONSTRAINTS, K_VARIABLE, FILTERING_FLAG, ALPHA),
@@ -923,7 +923,7 @@ GraphicalModelKsat::GraphicalModelKsat(int NUM_ITERATIONS, int NUM_VARIABLES, in
  *
  */
 
-void GraphicalModelKsat::initialize(const int *pUSED_VARIABLES_PY, const int *pVARIABLES_CONNECTIONS_PY, const int *pVARIABLES_CONNECTIONS_SIZES, const int *pCONSTRAINTS_CONNECTIONS,
+inline void GraphicalModelKsat::initialize(const int *pUSED_VARIABLES_PY, const int *pVARIABLES_CONNECTIONS_PY, const int *pVARIABLES_CONNECTIONS_SIZES, const int *pCONSTRAINTS_CONNECTIONS,
                                     const int *pCONSTRAINTS_CONNECTIONS_TYPE, const impalib_type *pINCOMING_METRICS_COST, impalib_type *pVariable_ec_to_ksat_constraint_m_py) {
     /// calls a method process_inputs() on an object modelInputs_, passing
     /// several pointers to Python objects as arguments
@@ -937,7 +937,7 @@ void GraphicalModelKsat::initialize(const int *pUSED_VARIABLES_PY, const int *pV
  *
  */
 
-void GraphicalModelKsat::iterate() {
+inline void GraphicalModelKsat::iterate() {
     for (int iter = 0; iter < numIterations_; iter++) {
         /// update messages from k-sat constraints to variable equality constraints
         modelKsatConstraint_.ksat_constraint_to_variable_ec_update(modelInputs_.VariableEc2KsatConstraintM, KsatConstraint2EqConstraintDummyM_, modelInputs_.ConstraintsConnections,

--- a/include/impalib/graphical_model.hpp
+++ b/include/impalib/graphical_model.hpp
@@ -41,8 +41,8 @@ class GraphicalModelKcMwm {
     InputsKcMwm modelInputs_;                                                                                                         ///< Graphical model inputs objects
     void initialize(const impalib_type *, impalib_type *, const int *, const int *, const int *, const impalib_type *, const int *);  ///< initialize graphical model
     void iterate(const int *);                                                                                                        ///< iterate over graphical model
-    GraphicalModelKcMwm(const int N_DEPARTMENTS, const int N_TEAMS, const int N_PROJECTS, const int MAX_SIZE_NON_ZERO_WEIGHTS, const int N_ITERATIONS, const bool FILT_FLAG,
-                        const impalib_type ALPHA);  ///< constructor
+    GraphicalModelKcMwm(int N_DEPARTMENTS, int N_TEAMS, int N_PROJECTS, int MAX_SIZE_NON_ZERO_WEIGHTS, int N_ITERATIONS, bool FILT_FLAG,
+                        impalib_type ALPHA);  ///< constructor
 };
 
 /**
@@ -198,10 +198,10 @@ class GraphicalModelTsp {
     vector<vector<impalib_type>> subtourConstraints2EdgeEcDummyM_;      ///< messages from subtour constraints to edge equality constraint before filtering
     vector<vector<impalib_type>> edgeEc2SubtourConstraintsM_;           ///< messages from edge equality constraint to subtour constraints
     void iterate_augmented_graph();                                     ///< function of IMPA on augmented graph
-    void subtour_elimination_constraints_analysis(unordered_map<int, vector<int>> &, vector<vector<int>> &);                    ///< analysis of subtour constraints
+    void subtour_elimination_constraints_analysis(unordered_map<int, vector<int>> &, const vector<vector<int>> &);                    ///< analysis of subtour constraints
     void hard_decision_analysis(vector<vector<int>> &);                                                                         ///< function for hard decision solution on IMPA solution
-    bool isSubsequence(const vector<int> &, const vector<int> &, int);                                                          ///< function for post-processing loops
-    vector<vector<int>> get_closed_loops(unordered_map<int, vector<int>> &, vector<vector<int>> &);                             ///< function for getting loops
+    static bool isSubsequence(const vector<int> &, const vector<int> &, int);                                                          ///< function for post-processing loops
+    vector<vector<int>> get_closed_loops(unordered_map<int, vector<int>> &, const vector<vector<int>> &);                             ///< function for getting loops
     vector<int> find_closed_loop(unordered_map<int, vector<int>> &, int, int, unordered_set<int>, vector<int>, vector<int> &);  ///< function for finding loops
     InputsTsp modelInputs_;                                                                                                     ///< Graphical Model Input object
     vector<vector<int>> selectedEdges_;                                                                                         ///< activated edges of IMPA
@@ -223,10 +223,10 @@ class GraphicalModelTsp {
     OutputsTsp outputs;                                                                                              ///< TSP graphical model outputs object
     void initialize(const int *, const impalib_type *, const impalib_type *, impalib_type *, const impalib_type *);  ///< initialize graphical model
     void iterate_relaxed_graph();                                                                                    ///< iterate over relaxed graphical model
-    void perform_augmentation(const int);                                                                            ///< perform augmentation on graphical model
+    void perform_augmentation(int);                                                                            ///< perform augmentation on graphical model
     void process_ouputs(impalib_type *, int *, int *, int *, impalib_type *, bool *, bool *, bool *, int *, int *, int *, int *);  ///< process outputs of Graphical Model
-    GraphicalModelTsp(const int NUM_ITERATIONS, const int NUM_NODES, const int NUM_EDGE_VARIABLES, const bool AUGMENTATION_FLAG, const bool RESET_FLAG, const bool FILTERING_FLAG,
-                      const impalib_type ALPHA, const impalib_type THRESHOLD, const int MAX_COUNT);  ///< Constructor
+    GraphicalModelTsp(int NUM_ITERATIONS, int NUM_NODES, int NUM_EDGE_VARIABLES, bool AUGMENTATION_FLAG, bool RESET_FLAG, bool FILTERING_FLAG,
+                       impalib_type ALPHA, impalib_type THRESHOLD, int MAX_COUNT);  ///< Constructor
 };
 
 /**
@@ -616,7 +616,7 @@ void GraphicalModelTsp::hard_decision_analysis(vector<vector<int>> &rSelectedEdg
  *
  */
 
-void GraphicalModelTsp::subtour_elimination_constraints_analysis(unordered_map<int, vector<int>> &rGraph, vector<vector<int>> &rSelectedEdges) {
+void GraphicalModelTsp::subtour_elimination_constraints_analysis(unordered_map<int, vector<int>> &rGraph, const vector<vector<int>> &rSelectedEdges) {
     closedPathsSize_.clear();  // just store it at the end if applicable
 
     // Get closed loops from the graph
@@ -708,7 +708,7 @@ void GraphicalModelTsp::subtour_elimination_constraints_analysis(unordered_map<i
  * @return new_loops_list: list of detected loops in rGraph
  *
  */
-vector<vector<int>> GraphicalModelTsp::get_closed_loops(unordered_map<int, vector<int>> &rGraph, vector<vector<int>> &rSelectedEdges) {
+vector<vector<int>> GraphicalModelTsp::get_closed_loops(unordered_map<int, vector<int>> &rGraph, const vector<vector<int>> &rSelectedEdges) {
     // Update the graph based on selected edges
     for (const auto &connection : rSelectedEdges) {
         if (rGraph.find(connection[0]) != rGraph.end()) {

--- a/include/impalib/graphical_model.hpp
+++ b/include/impalib/graphical_model.hpp
@@ -823,7 +823,7 @@ inline bool GraphicalModelTsp::isSubsequence(const vector<int> &seq, const vecto
  * between the nodes (if a tour is found, )
  *
  */
-inline vector<int> GraphicalModelTsp::find_closed_loop(unordered_map<int, vector<int>> &rGraph, int start_node, int current, unordered_set<int> visited, vector<int> path, vector<int> &visited_nodes) {
+inline vector<int> GraphicalModelTsp::find_closed_loop(unordered_map<int, vector<int>> &rGraph, const int start_node, const int current, unordered_set<int> visited, vector<int> path, vector<int> &visited_nodes) {
     visited.insert(current);
     path.push_back(current);
 
@@ -893,8 +893,8 @@ class GraphicalModelKsat {
  *
  */
 
-inline GraphicalModelKsat::GraphicalModelKsat(int NUM_ITERATIONS, int NUM_VARIABLES, int NUM_CONSTRAINTS, int K_VARIABLE, bool FILTERING_FLAG, impalib_type ALPHA,
-                                       int NUM_USED_VARIABLES)
+inline GraphicalModelKsat::GraphicalModelKsat(const int NUM_ITERATIONS, const int NUM_VARIABLES, const int NUM_CONSTRAINTS, const int K_VARIABLE, const bool FILTERING_FLAG, const impalib_type ALPHA,
+                                       const int NUM_USED_VARIABLES)
     : modelInputs_(NUM_VARIABLES, NUM_CONSTRAINTS, K_VARIABLE, numUsedVariables_),
       modelEqConstraint_(NUM_VARIABLES, NUM_CONSTRAINTS, K_VARIABLE, FILTERING_FLAG, ALPHA),
       modelKsatConstraint_(NUM_VARIABLES, NUM_CONSTRAINTS, K_VARIABLE, FILTERING_FLAG, ALPHA),

--- a/include/impalib/input_output.hpp
+++ b/include/impalib/input_output.hpp
@@ -339,7 +339,7 @@ class InputsKsat {
  *
  */
 
-inline InputsKsat::InputsKsat(int NUM_VARIABLES, int NUM_CONSTRAINTS, int K_VARIABLE, int NUM_USED_VARIABLES)
+inline InputsKsat::InputsKsat(const int NUM_VARIABLES, const int NUM_CONSTRAINTS, const int K_VARIABLE, const int NUM_USED_VARIABLES)
     : numVariables_(NUM_VARIABLES),
       numConstraints_(NUM_CONSTRAINTS),
       kVariable_(K_VARIABLE),

--- a/include/impalib/input_output.hpp
+++ b/include/impalib/input_output.hpp
@@ -59,7 +59,7 @@ class OutputsKcMwm {
  *
  */
 
-InputsKcMwm::InputsKcMwm(const int N_DEPARTMENTS, const int N_TEAMS, const int N_PROJECTS, const int MAX_SIZE_NON_ZERO_WEIGHTS)
+inline InputsKcMwm::InputsKcMwm(const int N_DEPARTMENTS, const int N_TEAMS, const int N_PROJECTS, const int MAX_SIZE_NON_ZERO_WEIGHTS)
     : numDepartments_(N_DEPARTMENTS), numTeams_(N_TEAMS), numProjects_(N_PROJECTS), maxSizeNonzeroWeights_(MAX_SIZE_NON_ZERO_WEIGHTS) {
     TeamsWeightsPerDepartment.reserve(numDepartments_);
     NonZeroWeightIndices.reserve(numDepartments_);
@@ -88,7 +88,7 @@ InputsKcMwm::InputsKcMwm(const int N_DEPARTMENTS, const int N_TEAMS, const int N
  *
  */
 
-void InputsKcMwm::process_inputs(const impalib_type *pREWARD_TEAM_PY, impalib_type *pTransition_model_py, const int *pTEAMS_WEIGHTS_PER_DEPARTMENT_PY, const int *pNON_ZERO_WEIGHT_INDICES_SIZES_PY,
+inline void InputsKcMwm::process_inputs(const impalib_type *pREWARD_TEAM_PY, impalib_type *pTransition_model_py, const int *pTEAMS_WEIGHTS_PER_DEPARTMENT_PY, const int *pNON_ZERO_WEIGHT_INDICES_SIZES_PY,
                                  const int *p_NON_ZERO_WEIGHT_INDICES_PY, const impalib_type *pREWARD_PROJECT_PY, const int *pMAX_STATE_PY) {
     copy(pREWARD_TEAM_PY, pREWARD_TEAM_PY + numTeams_, back_inserter(RewardTeam));
     copy(pMAX_STATE_PY, pMAX_STATE_PY + numDepartments_, back_inserter(MaxState));
@@ -116,7 +116,7 @@ void InputsKcMwm::process_inputs(const impalib_type *pREWARD_TEAM_PY, impalib_ty
  *
  */
 
-OutputsKcMwm::OutputsKcMwm(const int N_DEPARTMENTS, const int N_TEAMS, const int N_PROJECTS) : numDepartments_(N_DEPARTMENTS), numTeams_(N_TEAMS), numProjects_(N_PROJECTS) {
+inline OutputsKcMwm::OutputsKcMwm(const int N_DEPARTMENTS, const int N_TEAMS, const int N_PROJECTS) : numDepartments_(N_DEPARTMENTS), numTeams_(N_TEAMS), numProjects_(N_PROJECTS) {
     ExtrinsicOutputTeam.reserve(numTeams_);
     ExtrinsicOutputTeam.resize(numTeams_);
     fill(ExtrinsicOutputTeam.begin(), ExtrinsicOutputTeam.begin() + numTeams_, zero_value);
@@ -135,7 +135,7 @@ OutputsKcMwm::OutputsKcMwm(const int N_DEPARTMENTS, const int N_TEAMS, const int
  *
  */
 
-void OutputsKcMwm::intrinsic_out_mwm_update(const vector<vector<impalib_type>> &rOric2EqConstraintM, const vector<vector<impalib_type>> &rProject2EqConstraintM, const vector<vector<impalib_type>> &rRewardProject) {
+inline void OutputsKcMwm::intrinsic_out_mwm_update(const vector<vector<impalib_type>> &rOric2EqConstraintM, const vector<vector<impalib_type>> &rProject2EqConstraintM, const vector<vector<impalib_type>> &rRewardProject) {
     for (int project_index = 0; project_index < rRewardProject.size(); project_index++) {
         for (int team_index = 0; team_index < rRewardProject[project_index].size(); team_index++) {
             IntrinsicOutMwm[project_index + team_index + project_index * (numTeams_ - 1)] =
@@ -152,7 +152,7 @@ void OutputsKcMwm::intrinsic_out_mwm_update(const vector<vector<impalib_type>> &
  *
  */
 
-void OutputsKcMwm::extrinsic_output_team_update(vector<vector<impalib_type>> &rExtrinsicOutputDepartment, vector<impalib_type> &rOric2TeamM) {
+inline void OutputsKcMwm::extrinsic_output_team_update(vector<vector<impalib_type>> &rExtrinsicOutputDepartment, vector<impalib_type> &rOric2TeamM) {
     copy(rOric2TeamM.begin(), rOric2TeamM.end(), ExtrinsicOutputTeam.begin());
 
     for (int department_index = 0; department_index < rExtrinsicOutputDepartment.size(); department_index++) {
@@ -190,7 +190,7 @@ class InputsTsp {
  *
  */
 
-InputsTsp::InputsTsp(const int NUM_NODES, const int NUM_EDGE_VARIABLES) : numNodes_(NUM_NODES), numEdgeVariables_(NUM_EDGE_VARIABLES){};
+inline InputsTsp::InputsTsp(const int NUM_NODES, const int NUM_EDGE_VARIABLES) : numNodes_(NUM_NODES), numEdgeVariables_(NUM_EDGE_VARIABLES){};
 
 /**
  * Represents a class for outputs of TSP
@@ -218,7 +218,7 @@ class OutputsTsp {
  *
  */
 
-OutputsTsp::OutputsTsp(const int NUM_NODES, const int NUM_EDGE_VARIABLES) : numNodes_(NUM_NODES), numEdgeVariables_(NUM_EDGE_VARIABLES) {
+inline OutputsTsp::OutputsTsp(const int NUM_NODES, const int NUM_EDGE_VARIABLES) : numNodes_(NUM_NODES), numEdgeVariables_(NUM_EDGE_VARIABLES) {
     ExtrinsicOutputEdgeEc.reserve(numEdgeVariables_);
     ExtrinsicOutputEdgeEc.resize(numEdgeVariables_);
     IntrinsicOutputEdgeEc.reserve(numEdgeVariables_);
@@ -239,7 +239,7 @@ OutputsTsp::OutputsTsp(const int NUM_NODES, const int NUM_EDGE_VARIABLES) : numN
  *
  */
 
-void InputsTsp::process_inputs(const int *pEDGE_CONNECTIONS_PY, const impalib_type *pCOST_EDGE_VARIABLE_PY, const impalib_type *pCOST_MATRIX_PY, impalib_type *pEdge_ec_to_degree_constraint_m_py,
+inline void InputsTsp::process_inputs(const int *pEDGE_CONNECTIONS_PY, const impalib_type *pCOST_EDGE_VARIABLE_PY, const impalib_type *pCOST_MATRIX_PY, impalib_type *pEdge_ec_to_degree_constraint_m_py,
                                const impalib_type *pEDGE_DEGREE_CONSTRAINT_COST_PY) {
     copy(pCOST_EDGE_VARIABLE_PY, pCOST_EDGE_VARIABLE_PY + numEdgeVariables_, back_inserter(CostEdgeVariable));
 
@@ -269,7 +269,7 @@ void InputsTsp::process_inputs(const int *pEDGE_CONNECTIONS_PY, const impalib_ty
  *
  */
 
-void OutputsTsp::extrinsic_output_edge_ec_relaxed_graph_update(vector<vector<impalib_type>> &rDegreeConstraint2EqConstraintM) {
+inline void OutputsTsp::extrinsic_output_edge_ec_relaxed_graph_update(vector<vector<impalib_type>> &rDegreeConstraint2EqConstraintM) {
     for (int edge_variable_index = 0; edge_variable_index < rDegreeConstraint2EqConstraintM.size(); edge_variable_index++) {
         ExtrinsicOutputEdgeEc[edge_variable_index] = accumulate(rDegreeConstraint2EqConstraintM[edge_variable_index].begin(), rDegreeConstraint2EqConstraintM[edge_variable_index].end(), zero_value);
     }
@@ -283,7 +283,7 @@ void OutputsTsp::extrinsic_output_edge_ec_relaxed_graph_update(vector<vector<imp
  *
  */
 
-void OutputsTsp::extrinsic_output_edge_ec_augmented_graph_update(vector<vector<impalib_type>> &rDegreeConstraint2EqConstraintM, vector<vector<impalib_type>> &rSubtourConstraints2EdgeEcM) {
+inline void OutputsTsp::extrinsic_output_edge_ec_augmented_graph_update(vector<vector<impalib_type>> &rDegreeConstraint2EqConstraintM, vector<vector<impalib_type>> &rSubtourConstraints2EdgeEcM) {
     for (int edge_variable_index = 0; edge_variable_index < rDegreeConstraint2EqConstraintM.size(); edge_variable_index++) {
         ExtrinsicOutputEdgeEc[edge_variable_index] = accumulate(rDegreeConstraint2EqConstraintM[edge_variable_index].begin(), rDegreeConstraint2EqConstraintM[edge_variable_index].end(), zero_value);
     }
@@ -301,7 +301,7 @@ void OutputsTsp::extrinsic_output_edge_ec_augmented_graph_update(vector<vector<i
  *
  */
 
-void OutputsTsp::intrinsic_output_edge_ec_update(vector<impalib_type> &rCostEdgeVariable) {
+inline void OutputsTsp::intrinsic_output_edge_ec_update(vector<impalib_type> &rCostEdgeVariable) {
     transform(ExtrinsicOutputEdgeEc.begin(), ExtrinsicOutputEdgeEc.end(), rCostEdgeVariable.begin(), IntrinsicOutputEdgeEc.begin(), plus<impalib_type>());
 }
 
@@ -339,7 +339,7 @@ class InputsKsat {
  *
  */
 
-InputsKsat::InputsKsat(int NUM_VARIABLES, int NUM_CONSTRAINTS, int K_VARIABLE, int NUM_USED_VARIABLES)
+inline InputsKsat::InputsKsat(int NUM_VARIABLES, int NUM_CONSTRAINTS, int K_VARIABLE, int NUM_USED_VARIABLES)
     : numVariables_(NUM_VARIABLES),
       numConstraints_(NUM_CONSTRAINTS),
       kVariable_(K_VARIABLE),
@@ -371,7 +371,7 @@ class OutputsKsat {
  *
  */
 
-OutputsKsat::OutputsKsat(int NUM_VARIABLES, int NUM_CONSTRAINTS, int K_VARIABLE)
+inline OutputsKsat::OutputsKsat(int NUM_VARIABLES, int NUM_CONSTRAINTS, int K_VARIABLE)
     : numVariables_(NUM_VARIABLES), numConstraints_(NUM_CONSTRAINTS), kVariable_(K_VARIABLE), ExtrinsicOutputVariableEc(numVariables_, zero_value){};
 
 /**
@@ -387,7 +387,7 @@ OutputsKsat::OutputsKsat(int NUM_VARIABLES, int NUM_CONSTRAINTS, int K_VARIABLE)
  *
  */
 
-void InputsKsat::process_inputs(const int *pUSED_VARIABLES_PY, const int *pVARIABLES_CONNECTIONS_PY, const int *pVARIABLES_CONNECTIONS_SIZES, const int *pCONSTRAINTS_CONNECTIONS,
+inline void InputsKsat::process_inputs(const int *pUSED_VARIABLES_PY, const int *pVARIABLES_CONNECTIONS_PY, const int *pVARIABLES_CONNECTIONS_SIZES, const int *pCONSTRAINTS_CONNECTIONS,
                                 const int *pCONSTRAINTS_CONNECTIONS_TYPE, const impalib_type *pINCOMING_METRICS_COST, impalib_type *pVariable_ec_to_ksat_constraint_m_py) {
     copy(pUSED_VARIABLES_PY, pUSED_VARIABLES_PY + numUsedVariables_, back_inserter(UsedVariables));
 
@@ -434,7 +434,7 @@ void InputsKsat::process_inputs(const int *pUSED_VARIABLES_PY, const int *pVARIA
  *
  */
 
-void OutputsKsat::update_extrinsic(const vector<vector<impalib_type>> &rKsatConstraint2EqConstraintM) {
+inline void OutputsKsat::update_extrinsic(const vector<vector<impalib_type>> &rKsatConstraint2EqConstraintM) {
     // Sum all messages coming into equality constraint except the
     // incoming message on the edge of interest
     for (int i = 0; i < numVariables_; i++) {

--- a/include/impalib/input_output.hpp
+++ b/include/impalib/input_output.hpp
@@ -28,7 +28,7 @@ class InputsKcMwm {
 
     void process_inputs(const impalib_type *, impalib_type *, const int *, const int *, const int *, const impalib_type *, const int *);  ///< process input of graphical model
 
-    InputsKcMwm(const int N_DEPARTMENTS, const int N_TEAMS, const int N_PROJECTS, const int MAX_SIZE_NON_ZERO_WEIGHTS);  ///< constructor
+    InputsKcMwm(int N_DEPARTMENTS, int N_TEAMS, int N_PROJECTS, int MAX_SIZE_NON_ZERO_WEIGHTS);  ///< constructor
 };
 
 /**
@@ -43,10 +43,10 @@ class OutputsKcMwm {
    public:
     vector<impalib_type> ExtrinsicOutputTeam;  ///< extrinsic output of team equality constraints
     vector<impalib_type> IntrinsicOutMwm;      ///< intrinsic outputs of project equality constraint
-    void intrinsic_out_mwm_update(vector<vector<impalib_type>> &, vector<vector<impalib_type>> &,
-                                  vector<vector<impalib_type>> &);                              ///< calculate intrinsic outputs of project equality constraints
+    void intrinsic_out_mwm_update(const vector<vector<impalib_type>> &, const vector<vector<impalib_type>> &,
+                                  const vector<vector<impalib_type>> &);                              ///< calculate intrinsic outputs of project equality constraints
     void extrinsic_output_team_update(vector<vector<impalib_type>> &, vector<impalib_type> &);  ///< calculate extrinsic output of team equality constraints
-    OutputsKcMwm(const int N_DEPARTMENTS, const int N_TEAMS, const int N_PROJECTS);             ///< constructor
+    OutputsKcMwm(int N_DEPARTMENTS, int N_TEAMS, int N_PROJECTS);             ///< constructor
 };
 
 /**
@@ -135,7 +135,7 @@ OutputsKcMwm::OutputsKcMwm(const int N_DEPARTMENTS, const int N_TEAMS, const int
  *
  */
 
-void OutputsKcMwm::intrinsic_out_mwm_update(vector<vector<impalib_type>> &rOric2EqConstraintM, vector<vector<impalib_type>> &rProject2EqConstraintM, vector<vector<impalib_type>> &rRewardProject) {
+void OutputsKcMwm::intrinsic_out_mwm_update(const vector<vector<impalib_type>> &rOric2EqConstraintM, const vector<vector<impalib_type>> &rProject2EqConstraintM, const vector<vector<impalib_type>> &rRewardProject) {
     for (int project_index = 0; project_index < rRewardProject.size(); project_index++) {
         for (int team_index = 0; team_index < rRewardProject[project_index].size(); team_index++) {
             IntrinsicOutMwm[project_index + team_index + project_index * (numTeams_ - 1)] =
@@ -179,7 +179,7 @@ class InputsTsp {
 
     void process_inputs(const int *, const impalib_type *, const impalib_type *, impalib_type *, const impalib_type *);  ///< process inputs of TSP graphical model
 
-    InputsTsp(const int NUM_NODES, const int NUM_EDGE_VARIABLES);  ///< constructor
+    InputsTsp(int NUM_NODES, int NUM_EDGE_VARIABLES);  ///< constructor
 };
 
 /**
@@ -207,7 +207,7 @@ class OutputsTsp {
     void extrinsic_output_edge_ec_augmented_graph_update(vector<vector<impalib_type>> &,
                                                          vector<vector<impalib_type>> &);  ///< calculate extrinsic output of edge equality constraint for augmented TSP
     void intrinsic_output_edge_ec_update(vector<impalib_type> &);                          ///< calculate intrinsic output of edge equality constraint for augmented TSP
-    OutputsTsp(const int NUM_NODES, const int NUM_EDGE_VARIABLES);                         ///< constructor
+    OutputsTsp(int NUM_NODES, int NUM_EDGE_VARIABLES);                         ///< constructor
 };
 
 /**
@@ -359,7 +359,7 @@ class OutputsKsat {
    public:
     vector<impalib_type> ExtrinsicOutputVariableEc;                                         ///< extrinsic messages of variables equality constraints
     OutputsKsat(int NUM_VARIABLES, int NUM_CONSTRAINTS, int K_VARIABLE);  ///< constructor
-    void update_extrinsic(vector<vector<impalib_type>> &);                                  ///< calculate extrinsic messages of variables equality constraints
+    void update_extrinsic(const vector<vector<impalib_type>> &);                                  ///< calculate extrinsic messages of variables equality constraints
 };
 
 /**
@@ -434,7 +434,7 @@ void InputsKsat::process_inputs(const int *pUSED_VARIABLES_PY, const int *pVARIA
  *
  */
 
-void OutputsKsat::update_extrinsic(vector<vector<impalib_type>> &rKsatConstraint2EqConstraintM) {
+void OutputsKsat::update_extrinsic(const vector<vector<impalib_type>> &rKsatConstraint2EqConstraintM) {
     // Sum all messages coming into equality constraint except the
     // incoming message on the edge of interest
     for (int i = 0; i < numVariables_; i++) {

--- a/include/impalib/input_output.hpp
+++ b/include/impalib/input_output.hpp
@@ -56,10 +56,6 @@ class OutputsKcMwm {
  * @param[in] N_TEAMS: number of teams
  * @param[in] N_PROJECTS: number of projects
  * @param[in] MAX_SIZE_NON_ZERO_WEIGHTS: maximum number of connections between teams and departments
- * @param[out] numDepartments_: N_DEPARTMENTS
- * @param[out] numTeams_: N_TEAMS
- * @param[out] numProjects_: N_PROJECTS
- * @param[out] maxSizeNonzeroWeights_: MAX_SIZE_NON_ZERO_WEIGHTS
  *
  */
 
@@ -117,9 +113,6 @@ void InputsKcMwm::process_inputs(const impalib_type *pREWARD_TEAM_PY, impalib_ty
  * @param[in] N_DEPARTMENTS: number of departments
  * @param[in] N_TEAMS: number of teams
  * @param[in] N_PROJECTS: number of projects
- * @param[out] numDepartments_: N_DEPARTMENTS
- * @param[out] numTeams_: N_TEAMS
- * @param[out] numProjects_: N_PROJECTS
  *
  */
 
@@ -194,8 +187,6 @@ class InputsTsp {
  *
  * @param[in] NUM_NODES: number of nodes
  * @param[in] NUM_EDGE_VARIABLES: number of edge variables (edge connections)
- * @param[out] numNodes_: NUM_NODES
- * @param[out] numEdgeVariables_: NUM_EDGE_VARIABLES
  *
  */
 
@@ -224,8 +215,6 @@ class OutputsTsp {
  *
  * @param[in] NUM_NODES: number of nodes
  * @param[in] NUM_EDGE_VARIABLES: number of edge variables (edge connections)
- * @param[out] numNodes_: NUM_NODES
- * @param[out] numEdgeVariables_: NUM_EDGE_VARIABLES
  *
  */
 
@@ -347,10 +336,6 @@ class InputsKsat {
  * @param[in] NUM_CONSTRAINTS: number of constraints
  * @param[in] K_VARIABLE: ///< number of variables per constraint
  * @param[in] NUM_USED_VARIABLES: number of variables used to construct the formula
- * @param[out] numVariables_: NUM_VARIABLES
- * @param[out] numConstraints_: NUM_CONSTRAINTS
- * @param[out] kVariable_: K_VARIABLE'
- * @param[out] numUsedVariables_: NUM_USED_VARIABLES
  *
  */
 
@@ -383,9 +368,6 @@ class OutputsKsat {
  * @param[in] NUM_VARIABLES: total number of variables
  * @param[in] NUM_CONSTRAINTS: number of constraints
  * @param[in] K_VARIABLE: ///< number of variables per constraint
- * @param[out] numVariables_: NUM_VARIABLES
- * @param[out] numConstraints_: NUM_CONSTRAINTS
- * @param[out] kVariable_: K_VARIABLE'
  *
  */
 

--- a/include/impalib/knapsack.hpp
+++ b/include/impalib/knapsack.hpp
@@ -45,10 +45,6 @@ public:
  * @param[in] N_TEAMS: number of teams
  * @param[in] FILT_FLAG: filtering flag
  * @param[in] ALPHA: filtering parameter (between 0 and 1)
- * @param[out] numDepartments_: N_DEPARTMENTS
- * @param[out] numTeams_: N_TEAMS
- * @param[out] filteringFlag_: FILT_FLAG
- * @param[out] alpha_: ALPHA
  * 
  */
 

--- a/include/impalib/knapsack.hpp
+++ b/include/impalib/knapsack.hpp
@@ -21,21 +21,21 @@ private:
     vector<vector<impalib_type>> extrinsicOutputDepartmentOld_; ///< messages from departments to teams equality constraint before filtering
 
 public:
-    void forward(int, vector<vector<impalib_type>> &, int, vector<vector<int>> &, const int *, vector<vector<int>> &,
-                 vector<vector<impalib_type>> &); ///< forward pass of forward-backward algorithm
+    void forward(int, vector<vector<impalib_type>> &, int, vector<vector<int>> &, const int *, const vector<vector<int>> &,
+                 const vector<vector<impalib_type>> &) const; ///< forward pass of forward-backward algorithm
 
-    void backward(int, vector<vector<impalib_type>> &, int, vector<vector<int>> &, const int *, vector<vector<int>> &,
-                  vector<vector<impalib_type>> &); ///< backward pass of forward-backward algorithm
+    void backward(int, vector<vector<impalib_type>> &, int, vector<vector<int>> &, const int *, const vector<vector<int>> &,
+                  const vector<vector<impalib_type>> &) const; ///< backward pass of forward-backward algorithm
 
-    void extrinsic_output_department_lhs(vector<vector<int>> &, vector<vector<impalib_type>> &,
-                                         vector<vector<impalib_type>> &, int, vector<vector<impalib_type>> &, int,
+    static void extrinsic_output_department_lhs(const vector<vector<int>> &, const vector<vector<impalib_type>> &,
+                                         const vector<vector<impalib_type>> &, int, const vector<vector<impalib_type>> &, int,
                                          vector<vector<impalib_type>> &); ///< extrinsic output of department constraint
 
-    void team_to_knapsack_update(vector<vector<int>> &, vector<vector<impalib_type>> &, vector<impalib_type> &,
-                                 vector<vector<impalib_type>> &, vector<impalib_type> &); ///< calculate messages from teams to knapsack constraints
+    void team_to_knapsack_update(vector<vector<int>> &, vector<vector<impalib_type>> &, const vector<impalib_type> &,
+                                 const vector<vector<impalib_type>> &, const vector<impalib_type> &) const; ///< calculate messages from teams to knapsack constraints
     void process_extrinsic_output_department(int, int, vector<vector<impalib_type>> &, vector<vector<impalib_type>> &); ///< perform filtering (if needed) on messages from departments to teams
 
-    Knapsack(const int N_DEPARTMENTS, const int N_TEAMS, const bool FILT_FLAG, const impalib_type ALPHA); ///< constructor
+    Knapsack(int N_DEPARTMENTS, int N_TEAMS, bool FILT_FLAG, impalib_type ALPHA); ///< constructor
 };
 
 /**
@@ -73,10 +73,10 @@ Knapsack::Knapsack(const int N_DEPARTMENTS, const int N_TEAMS, const bool FILT_F
  * 
  */
 
-void Knapsack::forward(int department_index, vector<vector<impalib_type>> &rStageForwardMessages,
-                       int max_state_department, vector<vector<int>> &rNonZeroWeightIndices,
-                       const int *pNON_ZERO_WEIGHT_INDICES_SIZES_PY, vector<vector<int>> &rTeamsWeightsPerDepartment,
-                       vector<vector<impalib_type>> &rTeam2KnapsackM)
+void Knapsack::forward(const int department_index, vector<vector<impalib_type>> &rStageForwardMessages,
+                       const int max_state_department, vector<vector<int>> &rNonZeroWeightIndices,
+                       const int *pNON_ZERO_WEIGHT_INDICES_SIZES_PY, const vector<vector<int>> &rTeamsWeightsPerDepartment,
+                       const vector<vector<impalib_type>> &rTeam2KnapsackM) const
 {
     vector<int>::iterator upper;
 
@@ -160,10 +160,10 @@ void Knapsack::forward(int department_index, vector<vector<impalib_type>> &rStag
  * 
  */
 
-void Knapsack::backward(int department_index, vector<vector<impalib_type>> &rStageBackwardMessages,
-                        int max_state_department, vector<vector<int>> &rNonZeroWeightIndices,
-                        const int *pNON_ZERO_WEIGHT_INDICES_SIZES_PY, vector<vector<int>> &rTeamsWeightsPerDepartment,
-                        vector<vector<impalib_type>> &rTeam2KnapsackM)
+void Knapsack::backward(const int department_index, vector<vector<impalib_type>> &rStageBackwardMessages,
+                        const int max_state_department, vector<vector<int>> &rNonZeroWeightIndices,
+                        const int *pNON_ZERO_WEIGHT_INDICES_SIZES_PY, const vector<vector<int>> &rTeamsWeightsPerDepartment,
+                        const vector<vector<impalib_type>> &rTeam2KnapsackM) const
 {
 
     vector<int>::iterator upper;
@@ -248,11 +248,11 @@ void Knapsack::backward(int department_index, vector<vector<impalib_type>> &rSta
  * 
  */
 
-void Knapsack::extrinsic_output_department_lhs(vector<vector<int>>          &rTeamsWeightsPerDepartment,
-                                               vector<vector<impalib_type>> &rStageForwardMessages,
-                                               vector<vector<impalib_type>> &rTeam2KnapsackM, int department_index,
-                                               vector<vector<impalib_type>> &rStageBackwardMessages,
-                                               int                           max_state_department,
+void Knapsack::extrinsic_output_department_lhs(const vector<vector<int>>          &rTeamsWeightsPerDepartment,
+                                               const vector<vector<impalib_type>> &rStageForwardMessages,
+                                               const vector<vector<impalib_type>> &rTeam2KnapsackM, const int department_index,
+                                               const vector<vector<impalib_type>> &rStageBackwardMessages,
+                                               const int                           max_state_department,
                                                vector<vector<impalib_type>> &rExtrinsicOutputDepartment)
 {
 
@@ -318,9 +318,9 @@ void Knapsack::extrinsic_output_department_lhs(vector<vector<int>>          &rTe
  */
 
 void Knapsack::team_to_knapsack_update(vector<vector<int>>          &rNonZeroWeightIndices,
-                                       vector<vector<impalib_type>> &rTeam2KnapsackM, vector<impalib_type> &rRewardTeam,
-                                       vector<vector<impalib_type>> &rExtrinsicOutputDepartment,
-                                       vector<impalib_type>         &mORIC2Team)
+                                       vector<vector<impalib_type>> &rTeam2KnapsackM, const vector<impalib_type> &rRewardTeam,
+                                       const vector<vector<impalib_type>> &rExtrinsicOutputDepartment,
+                                       const vector<impalib_type>         &mORIC2Team) const
 {
     for (int department_index = 0; department_index < rExtrinsicOutputDepartment.size(); department_index++)
     {
@@ -389,9 +389,9 @@ void Knapsack::process_extrinsic_output_department(int department_index, int ite
 
         // Calculate weighted extrinsic outputs
         transform(intermediate_dummy.begin(), intermediate_dummy.end(), intermediate_dummy.begin(),
-                  [w_2](impalib_type &c) { return c * w_2; });
+                  [w_2](const impalib_type &c) { return c * w_2; });
         transform(intermediate_old.begin(), intermediate_old.end(), intermediate_old.begin(),
-                  [w_1](impalib_type &c) { return c * w_1; });
+                  [w_1](const impalib_type &c) { return c * w_1; });
 
         if (iter == 0)
         {

--- a/include/impalib/knapsack.hpp
+++ b/include/impalib/knapsack.hpp
@@ -27,7 +27,7 @@ public:
     void backward(int, vector<vector<impalib_type>> &, int, vector<vector<int>> &, const int *, const vector<vector<int>> &,
                   const vector<vector<impalib_type>> &) const; ///< backward pass of forward-backward algorithm
 
-    static void extrinsic_output_department_lhs(const vector<vector<int>> &, const vector<vector<impalib_type>> &,
+    void extrinsic_output_department_lhs(const vector<vector<int>> &, const vector<vector<impalib_type>> &,
                                          const vector<vector<impalib_type>> &, int, const vector<vector<impalib_type>> &, int,
                                          vector<vector<impalib_type>> &); ///< extrinsic output of department constraint
 

--- a/include/impalib/knapsack.hpp
+++ b/include/impalib/knapsack.hpp
@@ -48,7 +48,7 @@ public:
  * 
  */
 
-Knapsack::Knapsack(const int N_DEPARTMENTS, const int N_TEAMS, const bool FILT_FLAG, const impalib_type ALPHA)
+inline Knapsack::Knapsack(const int N_DEPARTMENTS, const int N_TEAMS, const bool FILT_FLAG, const impalib_type ALPHA)
     : numDepartments_(N_DEPARTMENTS), numTeams_(N_TEAMS), filteringFlag_(FILT_FLAG), alpha_(ALPHA)
 {
 
@@ -73,7 +73,7 @@ Knapsack::Knapsack(const int N_DEPARTMENTS, const int N_TEAMS, const bool FILT_F
  * 
  */
 
-void Knapsack::forward(const int department_index, vector<vector<impalib_type>> &rStageForwardMessages,
+inline void Knapsack::forward(const int department_index, vector<vector<impalib_type>> &rStageForwardMessages,
                        const int max_state_department, vector<vector<int>> &rNonZeroWeightIndices,
                        const int *pNON_ZERO_WEIGHT_INDICES_SIZES_PY, const vector<vector<int>> &rTeamsWeightsPerDepartment,
                        const vector<vector<impalib_type>> &rTeam2KnapsackM) const
@@ -160,7 +160,7 @@ void Knapsack::forward(const int department_index, vector<vector<impalib_type>> 
  * 
  */
 
-void Knapsack::backward(const int department_index, vector<vector<impalib_type>> &rStageBackwardMessages,
+inline void Knapsack::backward(const int department_index, vector<vector<impalib_type>> &rStageBackwardMessages,
                         const int max_state_department, vector<vector<int>> &rNonZeroWeightIndices,
                         const int *pNON_ZERO_WEIGHT_INDICES_SIZES_PY, const vector<vector<int>> &rTeamsWeightsPerDepartment,
                         const vector<vector<impalib_type>> &rTeam2KnapsackM) const
@@ -248,7 +248,7 @@ void Knapsack::backward(const int department_index, vector<vector<impalib_type>>
  * 
  */
 
-void Knapsack::extrinsic_output_department_lhs(const vector<vector<int>>          &rTeamsWeightsPerDepartment,
+inline void Knapsack::extrinsic_output_department_lhs(const vector<vector<int>>          &rTeamsWeightsPerDepartment,
                                                const vector<vector<impalib_type>> &rStageForwardMessages,
                                                const vector<vector<impalib_type>> &rTeam2KnapsackM, const int department_index,
                                                const vector<vector<impalib_type>> &rStageBackwardMessages,
@@ -317,7 +317,7 @@ void Knapsack::extrinsic_output_department_lhs(const vector<vector<int>>        
  * 
  */
 
-void Knapsack::team_to_knapsack_update(vector<vector<int>>          &rNonZeroWeightIndices,
+inline void Knapsack::team_to_knapsack_update(vector<vector<int>>          &rNonZeroWeightIndices,
                                        vector<vector<impalib_type>> &rTeam2KnapsackM, const vector<impalib_type> &rRewardTeam,
                                        const vector<vector<impalib_type>> &rExtrinsicOutputDepartment,
                                        const vector<impalib_type>         &mORIC2Team) const
@@ -374,7 +374,7 @@ void Knapsack::team_to_knapsack_update(vector<vector<int>>          &rNonZeroWei
  * 
  */
 
-void Knapsack::process_extrinsic_output_department(int department_index, int iter,
+inline void Knapsack::process_extrinsic_output_department(int department_index, int iter,
                                                    vector<vector<impalib_type>> &rExtrinsicOutputDepartmentDummy,
                                                    vector<vector<impalib_type>> &rExtrinsicOutputDepartment)
 {

--- a/include/impalib/knapsack.hpp
+++ b/include/impalib/knapsack.hpp
@@ -374,7 +374,7 @@ inline void Knapsack::team_to_knapsack_update(vector<vector<int>>          &rNon
  * 
  */
 
-inline void Knapsack::process_extrinsic_output_department(int department_index, int iter,
+inline void Knapsack::process_extrinsic_output_department(const int department_index, const int iter,
                                                    vector<vector<impalib_type>> &rExtrinsicOutputDepartmentDummy,
                                                    vector<vector<impalib_type>> &rExtrinsicOutputDepartment)
 {

--- a/include/impalib/knapsack.hpp
+++ b/include/impalib/knapsack.hpp
@@ -56,10 +56,8 @@ Knapsack::Knapsack(const int N_DEPARTMENTS, const int N_TEAMS, const bool FILT_F
     : numDepartments_(N_DEPARTMENTS), numTeams_(N_TEAMS), filteringFlag_(FILT_FLAG), alpha_(ALPHA)
 {
 
-    // Reserve memory for extrinsic output department
-    extrinsicOutputDepartmentOld_.reserve(numDepartments_);
-
     // Initialize extrinsic output department
+    extrinsicOutputDepartmentOld_.reserve(numDepartments_);
     for (int department_index = 0; department_index < numDepartments_; department_index++)
     {
         extrinsicOutputDepartmentOld_.push_back(vector<impalib_type>(numTeams_, zero_value));
@@ -84,7 +82,6 @@ void Knapsack::forward(int department_index, vector<vector<impalib_type>> &rStag
                        const int *pNON_ZERO_WEIGHT_INDICES_SIZES_PY, vector<vector<int>> &rTeamsWeightsPerDepartment,
                        vector<vector<impalib_type>> &rTeam2KnapsackM)
 {
-    // Initialize iterator
     vector<int>::iterator upper;
 
     // Initialize initial forward messages
@@ -103,11 +100,9 @@ void Knapsack::forward(int department_index, vector<vector<impalib_type>> &rStag
         }
     }
 
-    // Iterate over non-zero weight indices
     for (int l = 0; l < pNON_ZERO_WEIGHT_INDICES_SIZES_PY[department_index]; l++)
     {
         int t = rNonZeroWeightIndices[department_index][l];
-        // Iterate over states
         for (int a = 0; a <= max_state_department; a++)
         {
             if (a - rTeamsWeightsPerDepartment[department_index][t] >= 0
@@ -175,7 +170,6 @@ void Knapsack::backward(int department_index, vector<vector<impalib_type>> &rSta
                         vector<vector<impalib_type>> &rTeam2KnapsackM)
 {
 
-    // Initialize iterator
     vector<int>::iterator upper;
 
     // Initialize initial backward messages
@@ -194,12 +188,9 @@ void Knapsack::backward(int department_index, vector<vector<impalib_type>> &rSta
         }
     }
 
-    // Iterate over non-zero weight indices in reverse order
     for (int l = pNON_ZERO_WEIGHT_INDICES_SIZES_PY[department_index] - 1; l >= 0; l--)
     {
         int t = rNonZeroWeightIndices[department_index][l];
-
-        // Iterate over states
         for (int a = 0; a <= max_state_department; a++)
         {
             if ((t > 0 && a + rTeamsWeightsPerDepartment[department_index][t] <= max_state_department)
@@ -272,7 +263,6 @@ void Knapsack::extrinsic_output_department_lhs(vector<vector<int>>          &rTe
     // Initialize metric paths
     vector<impalib_type> metric_path_solid, metric_path_dash;
 
-    // Iterate over teams in the department
     for (int team_index = 0; team_index < rTeamsWeightsPerDepartment[department_index].size(); team_index++)
     {
         metric_path_dash.clear();
@@ -336,7 +326,6 @@ void Knapsack::team_to_knapsack_update(vector<vector<int>>          &rNonZeroWei
                                        vector<vector<impalib_type>> &rExtrinsicOutputDepartment,
                                        vector<impalib_type>         &mORIC2Team)
 {
-    // Iterate over departments
     for (int department_index = 0; department_index < rExtrinsicOutputDepartment.size(); department_index++)
     {
         // Create a list of remaining departments
@@ -347,7 +336,6 @@ void Knapsack::team_to_knapsack_update(vector<vector<int>>          &rNonZeroWei
         vector<int> unique_edge_department(rNonZeroWeightIndices[department_index]);
         remaining_departments.erase(remaining_departments.begin() + department_index);
 
-        // Iterate over remaining departments
         for (auto t : remaining_departments)
         {
             // Calculate intersection of non-zero weight indices between the current department and other departments
@@ -395,14 +383,12 @@ void Knapsack::process_extrinsic_output_department(int department_index, int ite
                                                    vector<vector<impalib_type>> &rExtrinsicOutputDepartment)
 {
 
-    // Check if filtering and alpha value are enabled
     if ((filteringFlag_) and (alpha_ != zero_value))
     {
 
         vector<impalib_type> intermediate_dummy(rExtrinsicOutputDepartmentDummy[department_index]),
             intermediate_old(extrinsicOutputDepartmentOld_[department_index]), intermediate_extrinsic;
-        
-        // Define weights
+
         impalib_type w_1 = alpha_, w_2 = 1 - alpha_;
 
         // Calculate weighted extrinsic outputs
@@ -411,7 +397,6 @@ void Knapsack::process_extrinsic_output_department(int department_index, int ite
         transform(intermediate_old.begin(), intermediate_old.end(), intermediate_old.begin(),
                   [w_1](impalib_type &c) { return c * w_1; });
 
-        // Update extrinsic output department based on the iteration
         if (iter == 0)
         {
             copy(intermediate_dummy.begin(), intermediate_dummy.end(),
@@ -419,7 +404,6 @@ void Knapsack::process_extrinsic_output_department(int department_index, int ite
         }
         else
         {
-            // Update extrinsic output department for the next iteration
             transform(intermediate_dummy.begin(), intermediate_dummy.end(), intermediate_old.begin(),
                       std::back_inserter(intermediate_extrinsic), std::plus<impalib_type>());
             copy(intermediate_extrinsic.begin(), intermediate_extrinsic.end(),
@@ -432,7 +416,6 @@ void Knapsack::process_extrinsic_output_department(int department_index, int ite
 
     else
     {
-        // Copy extrinsic output department directly
         copy(rExtrinsicOutputDepartmentDummy[department_index].begin(),
              rExtrinsicOutputDepartmentDummy[department_index].end(),
              rExtrinsicOutputDepartment[department_index].begin());

--- a/include/impalib/project_inequality_constraint.hpp
+++ b/include/impalib/project_inequality_constraint.hpp
@@ -27,9 +27,6 @@ public:
 /**
  * Construct InequalityConstraint object for the Knapsack-MWM problem
  *
- * @param[out] numProjects_: N_PROJECTS
- * @param[out] numTeams_: N_TEAMS
- * @param[out] numDepartments_: N_DEPARTMENTS
  * 
  */
 

--- a/include/impalib/project_inequality_constraint.hpp
+++ b/include/impalib/project_inequality_constraint.hpp
@@ -30,7 +30,7 @@ public:
  * 
  */
 
-InequalityConstraint::InequalityConstraint(const int N_DEPARTMENTS, const int N_TEAMS, const int N_PROJECTS)
+inline InequalityConstraint::InequalityConstraint(const int N_DEPARTMENTS, const int N_TEAMS, const int N_PROJECTS)
     : numProjects_(N_PROJECTS), numTeams_(N_TEAMS), numDepartments_(N_DEPARTMENTS){
                                                     };
 
@@ -42,7 +42,7 @@ InequalityConstraint::InequalityConstraint(const int N_DEPARTMENTS, const int N_
  * 
  */
 
-void InequalityConstraint::project_inequality_constraint_update(const vector<vector<impalib_type>> &rEqConstraint2ProjectM,
+inline void InequalityConstraint::project_inequality_constraint_update(const vector<vector<impalib_type>> &rEqConstraint2ProjectM,
                                                                 vector<vector<impalib_type>> &rProject2EqConstraintM) const
 {
 

--- a/include/impalib/project_inequality_constraint.hpp
+++ b/include/impalib/project_inequality_constraint.hpp
@@ -49,13 +49,11 @@ void InequalityConstraint::project_inequality_constraint_update(vector<vector<im
                                                                 vector<vector<impalib_type>> &rProject2EqConstraintM)
 {
 
-    // Define containers for forward and backward messages
     vector<vector<impalib_type>> stage_forward_messages_project_EC(numTeams_ + 1,
                                                                    vector<impalib_type>(maxStateIc_ + 1, zero_value));
     vector<vector<impalib_type>> stage_backward_messages_project_EC(numTeams_ + 1,
                                                                     vector<impalib_type>(maxStateIc_ + 1, zero_value));
 
-    // Iterate over projects
     for (int project_index = 0; project_index < rProject2EqConstraintM.size(); project_index++)
     {
         // Initialize forward messages
@@ -63,7 +61,6 @@ void InequalityConstraint::project_inequality_constraint_update(vector<vector<im
             initial_backward_messages(maxStateIc_ + 1, zero_value);
         fill(initial_forward_messages.begin() + 1, initial_forward_messages.end(), value_inf);
 
-        // Calculate forward messages
         stage_forward_messages_project_EC[0] = initial_forward_messages;
         
         for (int stage = 0; stage < numTeams_; stage++)
@@ -74,7 +71,6 @@ void InequalityConstraint::project_inequality_constraint_update(vector<vector<im
                     stage_forward_messages_project_EC[stage][0] + rEqConstraint2ProjectM[project_index][stage]);
         }
 
-        // Calculate backward messages
         stage_backward_messages_project_EC[numTeams_] = initial_backward_messages;
 
         for (int stage = numTeams_ - 1; stage >= 0; stage--)

--- a/include/impalib/project_inequality_constraint.hpp
+++ b/include/impalib/project_inequality_constraint.hpp
@@ -20,8 +20,8 @@ private:
     int maxStateIc_ = 1; ///< maximum value of project inequality constraint (<=1)
 
 public:
-    void project_inequality_constraint_update(vector<vector<impalib_type>> &, vector<vector<impalib_type>> &); ///< calculate messages from project inequality constraint to project equality constraint
-    InequalityConstraint(const int N_DEPARTMENTS, const int N_TEAMS, const int N_PROJECTS); ///< constructor
+    void project_inequality_constraint_update(const vector<vector<impalib_type>> &, vector<vector<impalib_type>> &) const; ///< calculate messages from project inequality constraint to project equality constraint
+    InequalityConstraint(int N_DEPARTMENTS, int N_TEAMS, int N_PROJECTS); ///< constructor
 };
 
 /**
@@ -42,8 +42,8 @@ InequalityConstraint::InequalityConstraint(const int N_DEPARTMENTS, const int N_
  * 
  */
 
-void InequalityConstraint::project_inequality_constraint_update(vector<vector<impalib_type>> &rEqConstraint2ProjectM,
-                                                                vector<vector<impalib_type>> &rProject2EqConstraintM)
+void InequalityConstraint::project_inequality_constraint_update(const vector<vector<impalib_type>> &rEqConstraint2ProjectM,
+                                                                vector<vector<impalib_type>> &rProject2EqConstraintM) const
 {
 
     vector<vector<impalib_type>> stage_forward_messages_project_EC(numTeams_ + 1,

--- a/include/impalib/subtour_elimination_constraint.hpp
+++ b/include/impalib/subtour_elimination_constraint.hpp
@@ -65,11 +65,9 @@ void SubtourEliminationConstraint::subtour_constraints_to_edge_ec_update(
     vector<vector<impalib_type>> &rEdgeEc2SubtourConstraintsM, vector<vector<int>> &rDeltaSIndicesList,
     vector<vector<impalib_type>> &rSubtourConstraints2EdgeEcM)
 {
-    // Define containers for forward and backward messages
     vector<impalib_type> stage_forward_messages(numEdgeVariables_ + 1, zero_value);
     vector<impalib_type> stage_backward_messages(numEdgeVariables_ + 1, zero_value);
 
-    // Iterate over subtour constraints
     for (size_t index_subtour_constraint = 0; index_subtour_constraint < rDeltaSIndicesList.size();
          index_subtour_constraint++)
     {
@@ -128,15 +126,12 @@ void SubtourEliminationConstraint::process_filtering(int                        
                                                      vector<vector<int>>          &rDeltaSIndicesList)
 {
 
-    // Iterate over subtour constraints
     for (int index_subtour_constraint = 0; index_subtour_constraint < rDeltaSIndicesList.size();
          index_subtour_constraint++)
     {
 
-        // Apply filtering if enabled and alpha is not zero
         if ((filteringFlag_) and (alpha_ != zero_value))
         {
-            // Calculate intermediate values based on alpha
             vector<impalib_type> intermediate_dummy(rSubtourConstraints2EdgeEcDummyM[index_subtour_constraint]),
                 intermediate_old(subtourConstraints2EdgeEcOld_[index_subtour_constraint]), intermediate_extrinsic;
 
@@ -145,8 +140,7 @@ void SubtourEliminationConstraint::process_filtering(int                        
                       [w_2](impalib_type &c) { return c * w_2; });
             transform(intermediate_old.begin(), intermediate_old.end(), intermediate_old.begin(),
                       [w_1](impalib_type &c) { return c * w_1; });
-            
-            // Update the messages based on iteration
+
             if (iter == 0)
             {
                 copy(intermediate_dummy.begin(), intermediate_dummy.end(),
@@ -160,13 +154,11 @@ void SubtourEliminationConstraint::process_filtering(int                        
                      rSubtourConstraints2EdgeEcM[index_subtour_constraint].begin());
             }
 
-            // Update the old messages for the next iteration
             copy(rSubtourConstraints2EdgeEcM[index_subtour_constraint].begin(),
                  rSubtourConstraints2EdgeEcM[index_subtour_constraint].end(),
                  subtourConstraints2EdgeEcOld_[index_subtour_constraint].begin());
         }
 
-        // If filtering is not enabled or alpha is zero, simply copy the dummy values
         else
         {
             copy(rSubtourConstraints2EdgeEcDummyM[index_subtour_constraint].begin(),

--- a/include/impalib/subtour_elimination_constraint.hpp
+++ b/include/impalib/subtour_elimination_constraint.hpp
@@ -39,12 +39,6 @@ public:
  * @param[in] NUM_EDGE_VARIABLES: number of connections between nodes
  * @param[in] FILTERING_FLAG: filtering on or off
  * @param[in] ALPHA: filtering parameter value (between 0 and 1)
- * @param[out] filteringFlag_: FILTERING_FLAG
- * @param[out] alpha_: ALPHA
- * @param[out] numNodes_: NUM_NODES
- * @param[out] numEdgeVariables_: NUM_EDGE_VARIABLES
- * @param[out] initial_forward_message_: set to infinity
- * @param[out] initial_backward_message_: set to infinity
  */
 SubtourEliminationConstraint::SubtourEliminationConstraint(const int NUM_NODES, const int NUM_EDGE_VARIABLES,
                                                            const bool FILTERING_FLAG, const impalib_type ALPHA)

--- a/include/impalib/subtour_elimination_constraint.hpp
+++ b/include/impalib/subtour_elimination_constraint.hpp
@@ -40,7 +40,7 @@ public:
  * @param[in] FILTERING_FLAG: filtering on or off
  * @param[in] ALPHA: filtering parameter value (between 0 and 1)
  */
-SubtourEliminationConstraint::SubtourEliminationConstraint(const int NUM_NODES, const int NUM_EDGE_VARIABLES,
+inline SubtourEliminationConstraint::SubtourEliminationConstraint(const int NUM_NODES, const int NUM_EDGE_VARIABLES,
                                                            const bool FILTERING_FLAG, const impalib_type ALPHA)
     : filteringFlag_(FILTERING_FLAG), alpha_(ALPHA), numNodes_(NUM_NODES), numEdgeVariables_(NUM_EDGE_VARIABLES),
       initial_forward_message_(value_inf), initial_backward_message_(value_inf){
@@ -55,7 +55,7 @@ SubtourEliminationConstraint::SubtourEliminationConstraint(const int NUM_NODES, 
  * 
  */
 
-void SubtourEliminationConstraint::subtour_constraints_to_edge_ec_update(
+inline void SubtourEliminationConstraint::subtour_constraints_to_edge_ec_update(
     const vector<vector<impalib_type>> &rEdgeEc2SubtourConstraintsM, const vector<vector<int>> &rDeltaSIndicesList,
     vector<vector<impalib_type>> &rSubtourConstraints2EdgeEcM) const
 {
@@ -114,7 +114,7 @@ void SubtourEliminationConstraint::subtour_constraints_to_edge_ec_update(
  * 
  */
 
-void SubtourEliminationConstraint::process_filtering(const int                           iter,
+inline void SubtourEliminationConstraint::process_filtering(const int                           iter,
                                                      vector<vector<impalib_type>> &rSubtourConstraints2EdgeEcDummyM,
                                                      vector<vector<impalib_type>> &rSubtourConstraints2EdgeEcM,
                                                      const vector<vector<int>>          &rDeltaSIndicesList)

--- a/include/impalib/subtour_elimination_constraint.hpp
+++ b/include/impalib/subtour_elimination_constraint.hpp
@@ -24,12 +24,12 @@ private:
 
 public:
     vector<vector<impalib_type>> subtourConstraints2EdgeEcOld_; ///< messages from subtour constraints to edge equality constraint before filtering
-    void subtour_constraints_to_edge_ec_update(vector<vector<impalib_type>> &, vector<vector<int>> &,
-                                               vector<vector<impalib_type>> &); ///< calculate messages from subtour to edge equality constraints
-    void process_filtering(int, vector<vector<impalib_type>> &, vector<vector<impalib_type>> &, vector<vector<int>> &); ///< perform filtering on messages from subtour to edge equality constraints
+    void subtour_constraints_to_edge_ec_update(const vector<vector<impalib_type>> &, const vector<vector<int>> &,
+                                               vector<vector<impalib_type>> &) const; ///< calculate messages from subtour to edge equality constraints
+    void process_filtering(int, vector<vector<impalib_type>> &, vector<vector<impalib_type>> &, const vector<vector<int>> &); ///< perform filtering on messages from subtour to edge equality constraints
 
-    SubtourEliminationConstraint(const int NUM_NODES, const int NUM_EDGE_VARIABLES, const bool FILTERING_FLAG,
-                                 const impalib_type ALPHA); ///< constructor
+    SubtourEliminationConstraint(int NUM_NODES, int NUM_EDGE_VARIABLES, bool FILTERING_FLAG,
+                                 impalib_type ALPHA); ///< constructor
 };
 
 /**
@@ -56,8 +56,8 @@ SubtourEliminationConstraint::SubtourEliminationConstraint(const int NUM_NODES, 
  */
 
 void SubtourEliminationConstraint::subtour_constraints_to_edge_ec_update(
-    vector<vector<impalib_type>> &rEdgeEc2SubtourConstraintsM, vector<vector<int>> &rDeltaSIndicesList,
-    vector<vector<impalib_type>> &rSubtourConstraints2EdgeEcM)
+    const vector<vector<impalib_type>> &rEdgeEc2SubtourConstraintsM, const vector<vector<int>> &rDeltaSIndicesList,
+    vector<vector<impalib_type>> &rSubtourConstraints2EdgeEcM) const
 {
     vector<impalib_type> stage_forward_messages(numEdgeVariables_ + 1, zero_value);
     vector<impalib_type> stage_backward_messages(numEdgeVariables_ + 1, zero_value);
@@ -114,10 +114,10 @@ void SubtourEliminationConstraint::subtour_constraints_to_edge_ec_update(
  * 
  */
 
-void SubtourEliminationConstraint::process_filtering(int                           iter,
+void SubtourEliminationConstraint::process_filtering(const int                           iter,
                                                      vector<vector<impalib_type>> &rSubtourConstraints2EdgeEcDummyM,
                                                      vector<vector<impalib_type>> &rSubtourConstraints2EdgeEcM,
-                                                     vector<vector<int>>          &rDeltaSIndicesList)
+                                                     const vector<vector<int>>          &rDeltaSIndicesList)
 {
 
     for (int index_subtour_constraint = 0; index_subtour_constraint < rDeltaSIndicesList.size();
@@ -131,9 +131,9 @@ void SubtourEliminationConstraint::process_filtering(int                        
 
             impalib_type w_1 = alpha_, w_2 = 1 - alpha_;
             transform(intermediate_dummy.begin(), intermediate_dummy.end(), intermediate_dummy.begin(),
-                      [w_2](impalib_type &c) { return c * w_2; });
+                      [w_2](const impalib_type &c) { return c * w_2; });
             transform(intermediate_old.begin(), intermediate_old.end(), intermediate_old.begin(),
-                      [w_1](impalib_type &c) { return c * w_1; });
+                      [w_1](const impalib_type &c) { return c * w_1; });
 
             if (iter == 0)
             {

--- a/include/impalib/update_degree_constraint.hpp
+++ b/include/impalib/update_degree_constraint.hpp
@@ -163,7 +163,7 @@ inline void DegreeConstraint::degree_constraint_to_edge_ec_update(
  * 
  */
 
-inline void DegreeConstraint::process_filtering(int iter, vector<vector<impalib_type>> &rDegreeConstraint2EqConstraintDummyM,
+inline void DegreeConstraint::process_filtering(const int iter, vector<vector<impalib_type>> &rDegreeConstraint2EqConstraintDummyM,
                                          vector<vector<impalib_type>> &rDegreeConstraint2EqConstraintM)
 {
     for (int edge_variable_index = 0; edge_variable_index < numEdgeVariables_; edge_variable_index++)

--- a/include/impalib/update_degree_constraint.hpp
+++ b/include/impalib/update_degree_constraint.hpp
@@ -51,10 +51,7 @@ DegreeConstraint::DegreeConstraint(const int NUM_NODES, const int NUM_EDGE_VARIA
     : filteringFlag_(FILTERING_FLAG), alpha_(ALPHA), numNodes_(NUM_NODES), numEdgeVariables_(NUM_EDGE_VARIABLES)
 {
 
-    // Reserve space for old degree constraint to equality constraint messages
     degreeConstraint2EqConstraintOld.reserve(numEdgeVariables_);
-
-    // Initialize old degree constraint to equality constraint messages
     for (int edge_variable_index = 0; edge_variable_index < numEdgeVariables_; edge_variable_index++)
     {
         degreeConstraint2EqConstraintOld.push_back(vector<impalib_type>(numNodes_, zero_value));
@@ -78,17 +75,14 @@ void DegreeConstraint::degree_constraint_to_edge_ec_update(
     vector<vector<impalib_type>> &rEdgeEc2DegreeConstraintM, vector<vector<int>> &rEdgeConnections,
     vector<vector<impalib_type>> &rDegreeConstraint2EqConstraintDummyM)
 {
-    // Initialize vectors to store forward and backward messages
     vector<impalib_type> stage_forward_messages(numEdgeVariables_ + 1, zero_value);
     vector<impalib_type> stage_backward_messages(numEdgeVariables_ + 1, zero_value);
 
-    // Iterate over each node
     for (int node_index = 0; node_index < numNodes_; node_index++)
     {
-        // Initialize vectors to store connections of the current node
         vector<int> connections_first, connections_second;
 
-        // Populate connections_first and connections_second with edge indices based on the current node
+        // Populate connections_first and connections_second with edge indices
         for (int i = 0; i < rEdgeConnections.size(); i++)
         {
             if (node_index == rEdgeConnections[i][0])
@@ -122,7 +116,6 @@ void DegreeConstraint::degree_constraint_to_edge_ec_update(
                     rEdgeEc2DegreeConstraintM[connections_first[stage]][node_index]);
         }
 
-        // Update rDegreeConstraint2EqConstraintDummyM for connections_first
         for (int index_edge_variable = 0; index_edge_variable < connections_first.size(); index_edge_variable++)
         {
             impalib_type minimumValue = zero_value;
@@ -131,11 +124,9 @@ void DegreeConstraint::degree_constraint_to_edge_ec_update(
             rDegreeConstraint2EqConstraintDummyM[connections_first[index_edge_variable]][node_index] = -minimumValue;
         }
 
-        // Reset stage_forward_messages and stage_backward_messages
         fill(stage_forward_messages.begin(), stage_forward_messages.end(), zero_value);
         fill(stage_backward_messages.begin(), stage_backward_messages.end(), zero_value);
 
-        // Similar calculations for connections_second
         // Calculate forward messages
         stage_forward_messages[connections_second[0]] = initial_forward_message_;
 
@@ -157,7 +148,6 @@ void DegreeConstraint::degree_constraint_to_edge_ec_update(
                     rEdgeEc2DegreeConstraintM[connections_second[stage]][node_index]);
         }
 
-        // Update rDegreeConstraint2EqConstraintDummyM for connections_second
         for (int index_edge_variable = 0; index_edge_variable < connections_second.size(); index_edge_variable++)
         {
             impalib_type minimumValue = zero_value;
@@ -180,10 +170,8 @@ void DegreeConstraint::degree_constraint_to_edge_ec_update(
 void DegreeConstraint::process_filtering(int iter, vector<vector<impalib_type>> &rDegreeConstraint2EqConstraintDummyM,
                                          vector<vector<impalib_type>> &rDegreeConstraint2EqConstraintM)
 {
-    // Iterate over each edge variable
     for (int edge_variable_index = 0; edge_variable_index < numEdgeVariables_; edge_variable_index++)
     {
-        // Check if filtering is enabled and alpha is not zero
         if ((filteringFlag_) and (alpha_ != zero_value))
         {
             // Calculate weighted values for current and old messages
@@ -195,7 +183,7 @@ void DegreeConstraint::process_filtering(int iter, vector<vector<impalib_type>> 
                       [w_2](impalib_type &c) { return c * w_2; });
             transform(intermediate_old.begin(), intermediate_old.end(), intermediate_old.begin(),
                       [w_1](impalib_type &c) { return c * w_1; });
-            // Update messages based on iteration
+
             if (iter == 0)
             {
                 copy(intermediate_dummy.begin(), intermediate_dummy.end(),
@@ -208,13 +196,11 @@ void DegreeConstraint::process_filtering(int iter, vector<vector<impalib_type>> 
                 copy(intermediate_extrinsic.begin(), intermediate_extrinsic.end(),
                      rDegreeConstraint2EqConstraintM[edge_variable_index].begin());
             }
-            // Update old messages with current messages
             copy(rDegreeConstraint2EqConstraintM[edge_variable_index].begin(),
                  rDegreeConstraint2EqConstraintM[edge_variable_index].end(),
                  degreeConstraint2EqConstraintOld[edge_variable_index].begin());
         }
 
-        // If filtering is not enabled or alpha is zero, copy dummy messages to current messages
         else
         {
             copy(rDegreeConstraint2EqConstraintDummyM[edge_variable_index].begin(),

--- a/include/impalib/update_degree_constraint.hpp
+++ b/include/impalib/update_degree_constraint.hpp
@@ -25,12 +25,12 @@ private:
     vector<vector<impalib_type>> stage_backward_messages; ///< backward messages of trellis representation
 
 public:
-    void degree_constraint_to_edge_ec_update(vector<vector<impalib_type>> &, vector<vector<int>> &,
-                                             vector<vector<impalib_type>> &); ///< calculate messages from degree constraint to edge equality constraint
+    void degree_constraint_to_edge_ec_update(const vector<vector<impalib_type>> &, const vector<vector<int>> &,
+                                             vector<vector<impalib_type>> &) const; ///< calculate messages from degree constraint to edge equality constraint
     void process_filtering(int, vector<vector<impalib_type>> &, vector<vector<impalib_type>> &); ///< process filtering on messages from degree constraint to edge equality constraint
 
-    DegreeConstraint(const int NUM_NODES, const int NUM_EDGE_VARIABLES, const bool FILTERING_FLAG,
-                     const impalib_type ALPHA); ///< constructor
+    DegreeConstraint(int NUM_NODES, int NUM_EDGE_VARIABLES, bool FILTERING_FLAG,
+                     impalib_type ALPHA); ///< constructor
 };
 
 /**
@@ -68,8 +68,8 @@ DegreeConstraint::DegreeConstraint(const int NUM_NODES, const int NUM_EDGE_VARIA
  */
 
 void DegreeConstraint::degree_constraint_to_edge_ec_update(
-    vector<vector<impalib_type>> &rEdgeEc2DegreeConstraintM, vector<vector<int>> &rEdgeConnections,
-    vector<vector<impalib_type>> &rDegreeConstraint2EqConstraintDummyM)
+    const vector<vector<impalib_type>> &rEdgeEc2DegreeConstraintM, const vector<vector<int>> &rEdgeConnections,
+    vector<vector<impalib_type>> &rDegreeConstraint2EqConstraintDummyM) const
 {
     vector<impalib_type> stage_forward_messages(numEdgeVariables_ + 1, zero_value);
     vector<impalib_type> stage_backward_messages(numEdgeVariables_ + 1, zero_value);
@@ -176,9 +176,9 @@ void DegreeConstraint::process_filtering(int iter, vector<vector<impalib_type>> 
 
             impalib_type w_1 = alpha_, w_2 = 1 - alpha_;
             transform(intermediate_dummy.begin(), intermediate_dummy.end(), intermediate_dummy.begin(),
-                      [w_2](impalib_type &c) { return c * w_2; });
+                      [w_2](const impalib_type &c) { return c * w_2; });
             transform(intermediate_old.begin(), intermediate_old.end(), intermediate_old.begin(),
-                      [w_1](impalib_type &c) { return c * w_1; });
+                      [w_1](const impalib_type &c) { return c * w_1; });
 
             if (iter == 0)
             {

--- a/include/impalib/update_degree_constraint.hpp
+++ b/include/impalib/update_degree_constraint.hpp
@@ -42,7 +42,7 @@ public:
  * @param[in] ALPHA: filtering parameter value (between 0 and 1)
  */
 
-DegreeConstraint::DegreeConstraint(const int NUM_NODES, const int NUM_EDGE_VARIABLES, const bool FILTERING_FLAG,
+inline DegreeConstraint::DegreeConstraint(const int NUM_NODES, const int NUM_EDGE_VARIABLES, const bool FILTERING_FLAG,
                                    const impalib_type ALPHA)
     : filteringFlag_(FILTERING_FLAG), alpha_(ALPHA), numNodes_(NUM_NODES), numEdgeVariables_(NUM_EDGE_VARIABLES)
 {
@@ -67,7 +67,7 @@ DegreeConstraint::DegreeConstraint(const int NUM_NODES, const int NUM_EDGE_VARIA
  * 
  */
 
-void DegreeConstraint::degree_constraint_to_edge_ec_update(
+inline void DegreeConstraint::degree_constraint_to_edge_ec_update(
     const vector<vector<impalib_type>> &rEdgeEc2DegreeConstraintM, const vector<vector<int>> &rEdgeConnections,
     vector<vector<impalib_type>> &rDegreeConstraint2EqConstraintDummyM) const
 {
@@ -163,7 +163,7 @@ void DegreeConstraint::degree_constraint_to_edge_ec_update(
  * 
  */
 
-void DegreeConstraint::process_filtering(int iter, vector<vector<impalib_type>> &rDegreeConstraint2EqConstraintDummyM,
+inline void DegreeConstraint::process_filtering(int iter, vector<vector<impalib_type>> &rDegreeConstraint2EqConstraintDummyM,
                                          vector<vector<impalib_type>> &rDegreeConstraint2EqConstraintM)
 {
     for (int edge_variable_index = 0; edge_variable_index < numEdgeVariables_; edge_variable_index++)

--- a/include/impalib/update_degree_constraint.hpp
+++ b/include/impalib/update_degree_constraint.hpp
@@ -40,10 +40,6 @@ public:
  * @param[in] NUM_EDGE_VARIABLES: number of connections between nodes
  * @param[in] FILTERING_FLAG: filtering on or off
  * @param[in] ALPHA: filtering parameter value (between 0 and 1)
- * @param[out] filteringFlag_: FILTERING_FLAG
- * @param[out] alpha_: ALPHA
- * @param[out] numNodes_: NUM_NODES
- * @param[out] numEdgeVariables_: NUM_EDGE_VARIABLES
  */
 
 DegreeConstraint::DegreeConstraint(const int NUM_NODES, const int NUM_EDGE_VARIABLES, const bool FILTERING_FLAG,

--- a/include/impalib/update_equality_constraint.hpp
+++ b/include/impalib/update_equality_constraint.hpp
@@ -41,26 +41,26 @@ public:
       numEdgeVariables_(0), numVariables_(NUM_VARIABLES), numConstraints_(NUM_CONSTRAINTS), kvariable_(K_VARIABLE){};
 
     void team_eq_constraint_to_oric_update(vector<vector<impalib_type>> &, vector<impalib_type> &,
-                                           vector<impalib_type> &); ///< calculate messages from team equality constraint to ORIC
+                                           vector<impalib_type> &) const; ///< calculate messages from team equality constraint to ORIC
 
-    void project_eq_constraint_to_oric_update(vector<vector<impalib_type>> &, vector<vector<impalib_type>> &,
+    static void project_eq_constraint_to_oric_update(vector<vector<impalib_type>> &, vector<vector<impalib_type>> &,
                                               vector<vector<impalib_type>> &); ///< calculate messages from project equality constraint to ORIC
 
-    void edge_ec_to_degree_constraint_relaxed_graph_update(vector<vector<int>> &, vector<vector<impalib_type>> &,
-                                                           vector<vector<impalib_type>> &,
-                                                           vector<vector<impalib_type>> &); ///< calculate messages from edge to degree constraints for relaxed TSP
+    void edge_ec_to_degree_constraint_relaxed_graph_update(const vector<vector<int>> &, vector<vector<impalib_type>> &,
+                                                           const vector<vector<impalib_type>> &,
+                                                           vector<vector<impalib_type>> &) const; ///< calculate messages from edge to degree constraints for relaxed TSP
     
-    void flip_matrix(vector<vector<impalib_type>> &, vector<vector<int>> &, vector<vector<impalib_type>> &); ///< flip matrix
-    vector<vector<impalib_type>> edge_ec_to_subtour_constraints_update(vector<vector<int>> &, vector<impalib_type> &,
-                                                                       vector<vector<impalib_type>> &,
-                                                                       vector<vector<impalib_type>> &,
-                                                                       vector<vector<int>> &); ///< calculate message from edge to subtour constraint
-    void                         edge_ec_to_degree_constraint_augmented_graph_update(vector<vector<impalib_type>> &,
-                                                                                     vector<vector<impalib_type>> &, vector<vector<int>> &,
-                                                                                     vector<vector<impalib_type>> &,
-                                                                                     vector<vector<impalib_type>> &); ///< calculate messages from edge to degree constraints for augmented TSP      
+    static void flip_matrix(const vector<vector<impalib_type>> &, const vector<vector<int>> &, vector<vector<impalib_type>> &); ///< flip matrix
+    vector<vector<impalib_type>> edge_ec_to_subtour_constraints_update(const vector<vector<int>> &, const vector<impalib_type> &,
+                                                                       const vector<vector<impalib_type>> &,
+                                                                       const vector<vector<impalib_type>> &,
+                                                                       const vector<vector<int>> &) const; ///< calculate message from edge to subtour constraint
+    void                         edge_ec_to_degree_constraint_augmented_graph_update(const vector<vector<impalib_type>> &,
+                                                                                     const vector<vector<impalib_type>> &, const vector<vector<int>> &,
+                                                                                     const vector<vector<impalib_type>> &,
+                                                                                     vector<vector<impalib_type>> &) const; ///< calculate messages from edge to degree constraints for augmented TSP
 
-    void variable_ec_to_ksat_constraint_update(vector<vector<impalib_type>> &, vector<vector<impalib_type>> &, vector<int> &, vector<impalib_type> &, vector<vector<int>> &);                                 
+    void variable_ec_to_ksat_constraint_update(const vector<vector<impalib_type>> &, vector<vector<impalib_type>> &, vector<int> &, const vector<impalib_type> &, const vector<vector<int>> &) const;
 };
 
 /**
@@ -73,7 +73,7 @@ public:
 
 void EqualityConstraint::team_eq_constraint_to_oric_update(
     vector<vector<impalib_type>> &rExtrinsicOutputDepartment, vector<impalib_type> &rTeam2OricM,
-    vector<impalib_type> &rewardTeam)
+    vector<impalib_type> &rewardTeam) const
 {
     vector<impalib_type> intermediate_team_to_oric_m(numTeams_, 0);
 
@@ -118,9 +118,9 @@ void EqualityConstraint::project_eq_constraint_to_oric_update(vector<vector<impa
  */
 
 void EqualityConstraint::edge_ec_to_degree_constraint_relaxed_graph_update(
-    vector<vector<int>> &rEdgeConnections, vector<vector<impalib_type>> &rEdgeDegreeConstraintCost,
-    vector<vector<impalib_type>> &rDegreeConstraint2EqConstraintM,
-    vector<vector<impalib_type>> &rEdgeEc2DegreeConstraintM)
+    const vector<vector<int>> &rEdgeConnections, vector<vector<impalib_type>> &rEdgeDegreeConstraintCost,
+    const vector<vector<impalib_type>> &rDegreeConstraint2EqConstraintM,
+    vector<vector<impalib_type>> &rEdgeEc2DegreeConstraintM) const
 {
 
     vector<vector<impalib_type>> flipped_degree_constraint_to_eq_constraint_m = rDegreeConstraint2EqConstraintM;
@@ -149,9 +149,9 @@ void EqualityConstraint::edge_ec_to_degree_constraint_relaxed_graph_update(
  */
 
 vector<vector<impalib_type>> EqualityConstraint::edge_ec_to_subtour_constraints_update(
-    vector<vector<int>> &rDeltaSIndicesList, vector<impalib_type> &rCostEdgeVaribale,
-    vector<vector<impalib_type>> &rDegreeConstraint2EqConstraintM,
-    vector<vector<impalib_type>> &rSubtourConstraints2EdgeEcM, vector<vector<int>> &rEdgeConnections)
+    const vector<vector<int>> &rDeltaSIndicesList, const vector<impalib_type> &rCostEdgeVaribale,
+    const vector<vector<impalib_type>> &rDegreeConstraint2EqConstraintM,
+    const vector<vector<impalib_type>> &rSubtourConstraints2EdgeEcM, const vector<vector<int>> &rEdgeConnections) const
 {
 
     vector<vector<impalib_type>> edge_ec_to_subtour_constraints_list;
@@ -227,9 +227,9 @@ vector<vector<impalib_type>> EqualityConstraint::edge_ec_to_subtour_constraints_
  */
 
 void EqualityConstraint::edge_ec_to_degree_constraint_augmented_graph_update(
-    vector<vector<impalib_type>> &rDegreeConstraint2EqConstraintM,
-    vector<vector<impalib_type>> &rSubtourConstraints2EdgeEcM, vector<vector<int>> &rEdgeConnections,
-    vector<vector<impalib_type>> &rEdgeDegreeConstraintCost, vector<vector<impalib_type>> &rEdgeEc2DegreeConstraintM)
+    const vector<vector<impalib_type>> &rDegreeConstraint2EqConstraintM,
+    const vector<vector<impalib_type>> &rSubtourConstraints2EdgeEcM, const vector<vector<int>> &rEdgeConnections,
+    const vector<vector<impalib_type>> &rEdgeDegreeConstraintCost, vector<vector<impalib_type>> &rEdgeEc2DegreeConstraintM) const
 {
 
     vector<impalib_type> combined_subtour_constraints_to_edge_ec_m(numEdgeVariables_, zero_value);
@@ -263,7 +263,7 @@ void EqualityConstraint::edge_ec_to_degree_constraint_augmented_graph_update(
  * 
  */
 
-void EqualityConstraint::flip_matrix(vector<vector<impalib_type>> &rMatrix, vector<vector<int>> &rEdgeConnections,
+void EqualityConstraint::flip_matrix(const vector<vector<impalib_type>> &rMatrix, const vector<vector<int>> &rEdgeConnections,
                                         vector<vector<impalib_type>> &rFlippedMatrix)
 {
     // Iterate over each edge connection
@@ -288,7 +288,7 @@ void EqualityConstraint::flip_matrix(vector<vector<impalib_type>> &rMatrix, vect
  *
  */
 
-void EqualityConstraint::variable_ec_to_ksat_constraint_update(vector<vector<impalib_type>> &rKsatConstraint2EqConstraintM_, vector<vector<impalib_type>> &rVariableEc2KsatConstraintM, vector<int> &rUsedVariables, vector<impalib_type> &rIncomingMetricsCost, vector<vector<int>> &rVariablesConnections)
+void EqualityConstraint::variable_ec_to_ksat_constraint_update(const vector<vector<impalib_type>> &rKsatConstraint2EqConstraintM_, vector<vector<impalib_type>> &rVariableEc2KsatConstraintM, vector<int> &rUsedVariables, const vector<impalib_type> &rIncomingMetricsCost, const vector<vector<int>> &rVariablesConnections) const
 {
 
     for(auto& row : rVariableEc2KsatConstraintM) {

--- a/include/impalib/update_equality_constraint.hpp
+++ b/include/impalib/update_equality_constraint.hpp
@@ -71,7 +71,7 @@ public:
  * @param[in] rewardTeam: rewards of teams
  */
 
-void EqualityConstraint::team_eq_constraint_to_oric_update(
+inline void EqualityConstraint::team_eq_constraint_to_oric_update(
     vector<vector<impalib_type>> &rExtrinsicOutputDepartment, vector<impalib_type> &rTeam2OricM,
     vector<impalib_type> &rewardTeam) const
 {
@@ -95,7 +95,7 @@ void EqualityConstraint::team_eq_constraint_to_oric_update(
  * @param[in] rewardProject: rewards of teams-projects combinations
  */
 
-void EqualityConstraint::project_eq_constraint_to_oric_update(vector<vector<impalib_type>> &rProject2EqConstraintM,
+inline void EqualityConstraint::project_eq_constraint_to_oric_update(vector<vector<impalib_type>> &rProject2EqConstraintM,
                                                                    vector<vector<impalib_type>> &rEqConstraint2OricM,
                                                                    vector<vector<impalib_type>> &rewardProject)
 {
@@ -117,7 +117,7 @@ void EqualityConstraint::project_eq_constraint_to_oric_update(vector<vector<impa
  * 
  */
 
-void EqualityConstraint::edge_ec_to_degree_constraint_relaxed_graph_update(
+inline void EqualityConstraint::edge_ec_to_degree_constraint_relaxed_graph_update(
     const vector<vector<int>> &rEdgeConnections, vector<vector<impalib_type>> &rEdgeDegreeConstraintCost,
     const vector<vector<impalib_type>> &rDegreeConstraint2EqConstraintM,
     vector<vector<impalib_type>> &rEdgeEc2DegreeConstraintM) const
@@ -148,7 +148,7 @@ void EqualityConstraint::edge_ec_to_degree_constraint_relaxed_graph_update(
  * 
  */
 
-vector<vector<impalib_type>> EqualityConstraint::edge_ec_to_subtour_constraints_update(
+inline vector<vector<impalib_type>> EqualityConstraint::edge_ec_to_subtour_constraints_update(
     const vector<vector<int>> &rDeltaSIndicesList, const vector<impalib_type> &rCostEdgeVaribale,
     const vector<vector<impalib_type>> &rDegreeConstraint2EqConstraintM,
     const vector<vector<impalib_type>> &rSubtourConstraints2EdgeEcM, const vector<vector<int>> &rEdgeConnections) const
@@ -226,7 +226,7 @@ vector<vector<impalib_type>> EqualityConstraint::edge_ec_to_subtour_constraints_
  * 
  */
 
-void EqualityConstraint::edge_ec_to_degree_constraint_augmented_graph_update(
+inline void EqualityConstraint::edge_ec_to_degree_constraint_augmented_graph_update(
     const vector<vector<impalib_type>> &rDegreeConstraint2EqConstraintM,
     const vector<vector<impalib_type>> &rSubtourConstraints2EdgeEcM, const vector<vector<int>> &rEdgeConnections,
     const vector<vector<impalib_type>> &rEdgeDegreeConstraintCost, vector<vector<impalib_type>> &rEdgeEc2DegreeConstraintM) const
@@ -263,7 +263,7 @@ void EqualityConstraint::edge_ec_to_degree_constraint_augmented_graph_update(
  * 
  */
 
-void EqualityConstraint::flip_matrix(const vector<vector<impalib_type>> &rMatrix, const vector<vector<int>> &rEdgeConnections,
+inline void EqualityConstraint::flip_matrix(const vector<vector<impalib_type>> &rMatrix, const vector<vector<int>> &rEdgeConnections,
                                         vector<vector<impalib_type>> &rFlippedMatrix)
 {
     // Iterate over each edge connection
@@ -288,7 +288,7 @@ void EqualityConstraint::flip_matrix(const vector<vector<impalib_type>> &rMatrix
  *
  */
 
-void EqualityConstraint::variable_ec_to_ksat_constraint_update(const vector<vector<impalib_type>> &rKsatConstraint2EqConstraintM_, vector<vector<impalib_type>> &rVariableEc2KsatConstraintM, vector<int> &rUsedVariables, const vector<impalib_type> &rIncomingMetricsCost, const vector<vector<int>> &rVariablesConnections) const
+inline void EqualityConstraint::variable_ec_to_ksat_constraint_update(const vector<vector<impalib_type>> &rKsatConstraint2EqConstraintM_, vector<vector<impalib_type>> &rVariableEc2KsatConstraintM, vector<int> &rUsedVariables, const vector<impalib_type> &rIncomingMetricsCost, const vector<vector<int>> &rVariablesConnections) const
 {
 
     for(auto& row : rVariableEc2KsatConstraintM) {

--- a/include/impalib/update_equality_constraint.hpp
+++ b/include/impalib/update_equality_constraint.hpp
@@ -75,18 +75,14 @@ void EqualityConstraint::team_eq_constraint_to_oric_update(
     vector<vector<impalib_type>> &rExtrinsicOutputDepartment, vector<impalib_type> &rTeam2OricM,
     vector<impalib_type> &rewardTeam)
 {
-    // Vector to store intermediate values for team to ORIC messages
     vector<impalib_type> intermediate_team_to_oric_m(numTeams_, 0);
 
-    // Iterate over each department
     for (int department_index = 0; department_index < rExtrinsicOutputDepartment.size(); department_index++)
     {
-        // Sum rExtrinsicOutputDepartment
         transform(rExtrinsicOutputDepartment[department_index].begin(),
                   rExtrinsicOutputDepartment[department_index].end(), intermediate_team_to_oric_m.begin(),
                   intermediate_team_to_oric_m.begin(), std::plus<impalib_type>());
     }
-    // Calculate rTeam2OricM
     transform(intermediate_team_to_oric_m.begin(), intermediate_team_to_oric_m.end(), rewardTeam.begin(),
               rTeam2OricM.begin(), std::plus<impalib_type>());
 }
@@ -103,10 +99,8 @@ void EqualityConstraint::project_eq_constraint_to_oric_update(vector<vector<impa
                                                                    vector<vector<impalib_type>> &rEqConstraint2OricM,
                                                                    vector<vector<impalib_type>> &rewardProject)
 {
-    // Iterate over each project
     for (int project_index = 0; project_index < rProject2EqConstraintM.size(); project_index++)
     {
-        // Transform and sum the messages from project to equality constraints and rewards for each project to get rEqConstraint2OricM
         transform(rProject2EqConstraintM[project_index].begin(), rProject2EqConstraintM[project_index].end(),
                   rewardProject[project_index].begin(), rEqConstraint2OricM[project_index].begin(),
                   std::plus<impalib_type>());
@@ -129,13 +123,9 @@ void EqualityConstraint::edge_ec_to_degree_constraint_relaxed_graph_update(
     vector<vector<impalib_type>> &rEdgeEc2DegreeConstraintM)
 {
 
-    // Create a copy of the messages from degree constraints to equality constraints
     vector<vector<impalib_type>> flipped_degree_constraint_to_eq_constraint_m = rDegreeConstraint2EqConstraintM;
-
-    // Flip the matrix representing the messages from degree constraints to equality constraints
     flip_matrix(rDegreeConstraint2EqConstraintM, rEdgeConnections, flipped_degree_constraint_to_eq_constraint_m);
 
-    // Update the messages from edge equality constraints to degree constraints
     for (int edge_variable_index = 0; edge_variable_index < numEdgeVariables_; edge_variable_index++)
     {
         transform(flipped_degree_constraint_to_eq_constraint_m[edge_variable_index].begin(),
@@ -166,63 +156,50 @@ vector<vector<impalib_type>> EqualityConstraint::edge_ec_to_subtour_constraints_
 
     vector<vector<impalib_type>> edge_ec_to_subtour_constraints_list;
 
-    // If there's only one subtour constraint
     if (rDeltaSIndicesList.size() == 1)
     {
-        // Initialize a vector to store the messages from edge equality constraints to subtour constraints
         vector<impalib_type> edge_ec_to_subtour_constraints_m(numEdgeVariables_, zero_value);
 
-        // Initialize a vector to store the combined messages from degree constraints to equality constraints
         vector<impalib_type> combined_degree_constraint_to_eq_constraint_m(numEdgeVariables_, zero_value);
         for (size_t index_edge_variable = 0; index_edge_variable < numEdgeVariables_; ++index_edge_variable)
         {
-            // Combine the messages from degree constraints to equality constraints for each edge variable
             combined_degree_constraint_to_eq_constraint_m[index_edge_variable] =
                 rDegreeConstraint2EqConstraintM[index_edge_variable][rEdgeConnections[index_edge_variable][0]]
                 + rDegreeConstraint2EqConstraintM[index_edge_variable][rEdgeConnections[index_edge_variable][1]];
         }
 
-        // Update the messages from edge equality constraints to subtour constraints
         for (size_t i = 0; i < rDeltaSIndicesList[0].size(); i++)
         {
             edge_ec_to_subtour_constraints_m[rDeltaSIndicesList[0][i]] =
                 combined_degree_constraint_to_eq_constraint_m[rDeltaSIndicesList[0][i]]
                 + rCostEdgeVaribale[rDeltaSIndicesList[0][i]];
         }
-        // Add the updated messages to the list
         edge_ec_to_subtour_constraints_list.push_back(edge_ec_to_subtour_constraints_m);
     }
     
     else
     {
-        // Initialize a vector to store the combined messages from subtour constraints to edge equality constraints
         vector<impalib_type> combined_subtour_constraints_to_edge_ec_m(numEdgeVariables_, zero_value);
         for (const auto &row : rSubtourConstraints2EdgeEcM)
         {
-            // Sum the messages from subtour constraints to edge equality constraints for each edge variable
             transform(combined_subtour_constraints_to_edge_ec_m.begin(),
                       combined_subtour_constraints_to_edge_ec_m.end(), row.begin(),
                       combined_subtour_constraints_to_edge_ec_m.begin(), std::plus<impalib_type>());
         }
 
-        // Initialize a vector to store the combined messages from degree constraints to equality constraints
         vector<impalib_type> combined_degree_constraint_to_eq_constraint_m(numEdgeVariables_, zero_value);
         for (size_t index_edge_variable = 0; index_edge_variable < numEdgeVariables_; ++index_edge_variable)
         {
-            // Combine the messages from degree constraints to equality constraints for each edge variable
             combined_degree_constraint_to_eq_constraint_m[index_edge_variable] =
                 rDegreeConstraint2EqConstraintM[index_edge_variable][rEdgeConnections[index_edge_variable][0]]
                 + rDegreeConstraint2EqConstraintM[index_edge_variable][rEdgeConnections[index_edge_variable][1]];
         }
 
-        // Iterate over each subtour constraint
         for (size_t index_subtour_constraint = 0; index_subtour_constraint < rDeltaSIndicesList.size();
              index_subtour_constraint++)
         {
-            // Initialize a vector to store the messages from edge equality constraints to subtour constraints
             vector<impalib_type> edge_ec_to_subtour_constraints_m(numEdgeVariables_, zero_value);
 
-            // Update the messages from edge equality constraints to subtour constraints
             for (size_t i = 0; i < rDeltaSIndicesList[index_subtour_constraint].size(); i++)
             {
                 edge_ec_to_subtour_constraints_m[rDeltaSIndicesList[index_subtour_constraint][i]] =
@@ -232,11 +209,9 @@ vector<vector<impalib_type>> EqualityConstraint::edge_ec_to_subtour_constraints_
                     - rSubtourConstraints2EdgeEcM[index_subtour_constraint]
                                                  [rDeltaSIndicesList[index_subtour_constraint][i]];
             }
-            // Add the updated messages to the list
             edge_ec_to_subtour_constraints_list.push_back(edge_ec_to_subtour_constraints_m);
         }
     }
-    // Return the list of udpated messages from edge equality constraints to subtour constraints
     return edge_ec_to_subtour_constraints_list;
 }
 
@@ -257,16 +232,13 @@ void EqualityConstraint::edge_ec_to_degree_constraint_augmented_graph_update(
     vector<vector<impalib_type>> &rEdgeDegreeConstraintCost, vector<vector<impalib_type>> &rEdgeEc2DegreeConstraintM)
 {
 
-    // Initialize a vector to store the combined messages from subtour constraints to edge equality constraints
     vector<impalib_type> combined_subtour_constraints_to_edge_ec_m(numEdgeVariables_, zero_value);
     for (const auto &row : rSubtourConstraints2EdgeEcM)
     {
-        // Sum the messages from subtour constraints to edge equality constraints for each edge variable
         transform(combined_subtour_constraints_to_edge_ec_m.begin(), combined_subtour_constraints_to_edge_ec_m.end(),
                   row.begin(), combined_subtour_constraints_to_edge_ec_m.begin(), std::plus<impalib_type>());
     }
 
-    // Update the messages from edge equality constraints to degree constraints
     for (size_t i = 0; i < rEdgeConnections.size(); i++)
     {
 

--- a/include/impalib/update_equality_constraint.hpp
+++ b/include/impalib/update_equality_constraint.hpp
@@ -23,7 +23,7 @@ private:
     int kvariable_;
 public:
 
-    EqualityConstraint(int N_DEPARTMENTS, int N_TEAMS, int N_PROJECTS)
+    EqualityConstraint(const int N_DEPARTMENTS, const int N_TEAMS, const int N_PROJECTS)
     : numProjects_(N_PROJECTS), numTeams_(N_TEAMS), numDepartments_(N_DEPARTMENTS), 
         filteringFlag_(false), alpha_(zero_value), numNodes_(0), numEdgeVariables_(0),
         numVariables_(0), numConstraints_(0), kvariable_(0){};

--- a/include/impalib/update_ksat_constraint.hpp
+++ b/include/impalib/update_ksat_constraint.hpp
@@ -42,7 +42,7 @@ class KsatConstraint {
  * @param[in] ALPHA: filtering parameter value (between 0 and 1)
  */
 
-inline KsatConstraint::KsatConstraint(int NUM_VARIABLES, int NUM_CONSTRAINTS, int K_VARIABLE, bool FILTERING_FLAG, impalib_type ALPHA)
+inline KsatConstraint::KsatConstraint(const int NUM_VARIABLES, const int NUM_CONSTRAINTS, const int K_VARIABLE, const bool FILTERING_FLAG, const impalib_type ALPHA)
     : filteringFlag_(FILTERING_FLAG),
       alpha_(ALPHA),
       numVariables_(NUM_VARIABLES),
@@ -136,7 +136,7 @@ inline void KsatConstraint::ksat_constraint_to_variable_ec_update(const vector<v
  *
  */
 
-inline void KsatConstraint::process_filtering(int iter, vector<vector<impalib_type>> &rKsatConstraint2EqConstraintDummyM_, vector<vector<impalib_type>> &rKsatConstraint2EqConstraintM_) {
+inline void KsatConstraint::process_filtering(const int iter, vector<vector<impalib_type>> &rKsatConstraint2EqConstraintDummyM_, vector<vector<impalib_type>> &rKsatConstraint2EqConstraintM_) {
     for (int c = 0; c < numConstraints_; c++) {
         if ((filteringFlag_) and (alpha_ != zero_value)) {
             vector<impalib_type> intermediate_dummy(rKsatConstraint2EqConstraintDummyM_[c]), intermediate_old(ksatConstraint2EqConstraintOld[c]), intermediate_extrinsic;

--- a/include/impalib/update_ksat_constraint.hpp
+++ b/include/impalib/update_ksat_constraint.hpp
@@ -24,8 +24,8 @@ class KsatConstraint {
     int maxState_ = 1; 
 
    public:
-    void ksat_constraint_to_variable_ec_update(vector<vector<impalib_type>> &, vector<vector<impalib_type>> &, vector<vector<int>> &,
-                                               vector<vector<int>> &);                            ///< update messages from k-sat constraints to equality constraints
+    void ksat_constraint_to_variable_ec_update(const vector<vector<impalib_type>> &, vector<vector<impalib_type>> &, const vector<vector<int>> &,
+                                               const vector<vector<int>> &) const;                            ///< update messages from k-sat constraints to equality constraints
     void process_filtering(int, vector<vector<impalib_type>> &, vector<vector<impalib_type>> &);  ///< perform filtering
 
     KsatConstraint(int NUM_VARIABLES, int NUM_CONSTRAINTS, int K_VARIABLE, bool FILTERING_FLAG,
@@ -60,8 +60,8 @@ KsatConstraint::KsatConstraint(int NUM_VARIABLES, int NUM_CONSTRAINTS, int K_VAR
  *
  */
 
-void KsatConstraint::ksat_constraint_to_variable_ec_update(vector<vector<impalib_type>> &rVariableEc2KsatConstraintM, vector<vector<impalib_type>> &rKsatConstraint2EqConstraintDummyM_,
-                                                           vector<vector<int>> &rConstraintsConnections, vector<vector<int>> &rConstraintsConnectionsType) {
+void KsatConstraint::ksat_constraint_to_variable_ec_update(const vector<vector<impalib_type>> &rVariableEc2KsatConstraintM, vector<vector<impalib_type>> &rKsatConstraint2EqConstraintDummyM_,
+                                                           const vector<vector<int>> &rConstraintsConnections, const vector<vector<int>> &rConstraintsConnectionsType) const {
 
     for(auto& row : rKsatConstraint2EqConstraintDummyM_) {
         row.assign(row.size(), zero_value);
@@ -142,8 +142,8 @@ void KsatConstraint::process_filtering(int iter, vector<vector<impalib_type>> &r
             vector<impalib_type> intermediate_dummy(rKsatConstraint2EqConstraintDummyM_[c]), intermediate_old(ksatConstraint2EqConstraintOld[c]), intermediate_extrinsic;
 
             impalib_type w_1 = alpha_, w_2 = 1 - alpha_;
-            transform(intermediate_dummy.begin(), intermediate_dummy.end(), intermediate_dummy.begin(), [w_2](impalib_type &c) { return c * w_2; });
-            transform(intermediate_old.begin(), intermediate_old.end(), intermediate_old.begin(), [w_1](impalib_type &c) { return c * w_1; });
+            transform(intermediate_dummy.begin(), intermediate_dummy.end(), intermediate_dummy.begin(), [w_2](const impalib_type &c) { return c * w_2; });
+            transform(intermediate_old.begin(), intermediate_old.end(), intermediate_old.begin(), [w_1](const impalib_type &c) { return c * w_1; });
 
             if (iter == 0) {
                 copy(intermediate_dummy.begin(), intermediate_dummy.end(), rKsatConstraint2EqConstraintM_[c].begin());

--- a/include/impalib/update_ksat_constraint.hpp
+++ b/include/impalib/update_ksat_constraint.hpp
@@ -42,7 +42,7 @@ class KsatConstraint {
  * @param[in] ALPHA: filtering parameter value (between 0 and 1)
  */
 
-KsatConstraint::KsatConstraint(int NUM_VARIABLES, int NUM_CONSTRAINTS, int K_VARIABLE, bool FILTERING_FLAG, impalib_type ALPHA)
+inline KsatConstraint::KsatConstraint(int NUM_VARIABLES, int NUM_CONSTRAINTS, int K_VARIABLE, bool FILTERING_FLAG, impalib_type ALPHA)
     : filteringFlag_(FILTERING_FLAG),
       alpha_(ALPHA),
       numVariables_(NUM_VARIABLES),
@@ -60,7 +60,7 @@ KsatConstraint::KsatConstraint(int NUM_VARIABLES, int NUM_CONSTRAINTS, int K_VAR
  *
  */
 
-void KsatConstraint::ksat_constraint_to_variable_ec_update(const vector<vector<impalib_type>> &rVariableEc2KsatConstraintM, vector<vector<impalib_type>> &rKsatConstraint2EqConstraintDummyM_,
+inline void KsatConstraint::ksat_constraint_to_variable_ec_update(const vector<vector<impalib_type>> &rVariableEc2KsatConstraintM, vector<vector<impalib_type>> &rKsatConstraint2EqConstraintDummyM_,
                                                            const vector<vector<int>> &rConstraintsConnections, const vector<vector<int>> &rConstraintsConnectionsType) const {
 
     for(auto& row : rKsatConstraint2EqConstraintDummyM_) {
@@ -136,7 +136,7 @@ void KsatConstraint::ksat_constraint_to_variable_ec_update(const vector<vector<i
  *
  */
 
-void KsatConstraint::process_filtering(int iter, vector<vector<impalib_type>> &rKsatConstraint2EqConstraintDummyM_, vector<vector<impalib_type>> &rKsatConstraint2EqConstraintM_) {
+inline void KsatConstraint::process_filtering(int iter, vector<vector<impalib_type>> &rKsatConstraint2EqConstraintDummyM_, vector<vector<impalib_type>> &rKsatConstraint2EqConstraintM_) {
     for (int c = 0; c < numConstraints_; c++) {
         if ((filteringFlag_) and (alpha_ != zero_value)) {
             vector<impalib_type> intermediate_dummy(rKsatConstraint2EqConstraintDummyM_[c]), intermediate_old(ksatConstraint2EqConstraintOld[c]), intermediate_extrinsic;

--- a/include/impalib/update_ksat_constraint.hpp
+++ b/include/impalib/update_ksat_constraint.hpp
@@ -40,11 +40,6 @@ class KsatConstraint {
  * @param[in] K_VARIABLE: number of variables per constraint
  * @param[in] FILTERING_FLAG: filtering on or off
  * @param[in] ALPHA: filtering parameter value (between 0 and 1)
- * @param[out] filteringFlag_: FILTERING_FLAG
- * @param[out] alpha_: ALPHA
- * @param[out] numVariables_: NUM_VARIABLES
- * @param[out] numConstraints_: NUM_CONSTRAINTS
- * @param[out] kVariable_: K_VARIABLE
  */
 
 KsatConstraint::KsatConstraint(int NUM_VARIABLES, int NUM_CONSTRAINTS, int K_VARIABLE, bool FILTERING_FLAG, impalib_type ALPHA)

--- a/include/impalib/update_or_inequality_constraint.hpp
+++ b/include/impalib/update_or_inequality_constraint.hpp
@@ -38,7 +38,7 @@ public:
  * 
  */
 
-OrInequalityConstraint::OrInequalityConstraint(const int N_DEPARTMENTS, const int N_TEAMS, const int N_PROJECTS)
+inline OrInequalityConstraint::OrInequalityConstraint(const int N_DEPARTMENTS, const int N_TEAMS, const int N_PROJECTS)
     : numProjects_(N_PROJECTS), numTeams_(N_TEAMS), numDepartments_(N_DEPARTMENTS){
                                                     };
 
@@ -53,7 +53,7 @@ OrInequalityConstraint::OrInequalityConstraint(const int N_DEPARTMENTS, const in
  * 
  */
 
-void OrInequalityConstraint::oric_to_project_eq_constraint_update(const vector<vector<impalib_type>> &rEqConstraint2OricM,
+inline void OrInequalityConstraint::oric_to_project_eq_constraint_update(const vector<vector<impalib_type>> &rEqConstraint2OricM,
                                                                   const vector<impalib_type>         &mTeam2ORIC,
                                                                   vector<vector<impalib_type>> &rOric2EqConstraintM,
                                                                   vector<vector<impalib_type>> &rEqConstraint2ProjectM,
@@ -117,7 +117,7 @@ void OrInequalityConstraint::oric_to_project_eq_constraint_update(const vector<v
  * 
  */
 
-void OrInequalityConstraint::oric_to_team_update(const vector<vector<impalib_type>> &rEqConstraint2OricM,
+inline void OrInequalityConstraint::oric_to_team_update(const vector<vector<impalib_type>> &rEqConstraint2OricM,
                                                  vector<impalib_type>         &rOric2TeamM)
 {
     for (int team_index = 0; team_index < rOric2TeamM.size(); team_index++)

--- a/include/impalib/update_or_inequality_constraint.hpp
+++ b/include/impalib/update_or_inequality_constraint.hpp
@@ -20,13 +20,13 @@ private:
     int maxStateIc_ = 1; ///< maximum state of inequality constraint (>=1)
 
 public:
-    void oric_to_project_eq_constraint_update(vector<vector<impalib_type>> &, vector<impalib_type> &,
+    void oric_to_project_eq_constraint_update(const vector<vector<impalib_type>> &, const vector<impalib_type> &,
                                               vector<vector<impalib_type>> &, vector<vector<impalib_type>> &,
-                                              vector<vector<impalib_type>> &); ///< update messages from ORIC to project equality constraint
+                                              const vector<vector<impalib_type>> &) const; ///< update messages from ORIC to project equality constraint
 
-    void oric_to_team_update(vector<vector<impalib_type>> &, vector<impalib_type> &); ///< calculate messages from team ORIC to team equality constraint
+    static void oric_to_team_update(const vector<vector<impalib_type>> &, vector<impalib_type> &); ///< calculate messages from team ORIC to team equality constraint
 
-    OrInequalityConstraint(const int N_DEPARTMENTS, const int N_TEAMS, const int N_PROJECTS); ///< constructor
+    OrInequalityConstraint(int N_DEPARTMENTS, int N_TEAMS, int N_PROJECTS); ///< constructor
 };
 
 /**
@@ -53,11 +53,11 @@ OrInequalityConstraint::OrInequalityConstraint(const int N_DEPARTMENTS, const in
  * 
  */
 
-void OrInequalityConstraint::oric_to_project_eq_constraint_update(vector<vector<impalib_type>> &rEqConstraint2OricM,
-                                                                  vector<impalib_type>         &mTeam2ORIC,
+void OrInequalityConstraint::oric_to_project_eq_constraint_update(const vector<vector<impalib_type>> &rEqConstraint2OricM,
+                                                                  const vector<impalib_type>         &mTeam2ORIC,
                                                                   vector<vector<impalib_type>> &rOric2EqConstraintM,
                                                                   vector<vector<impalib_type>> &rEqConstraint2ProjectM,
-                                                                  vector<vector<impalib_type>> &rRewardProject)
+                                                                  const vector<vector<impalib_type>> &rRewardProject) const
 {
     vector<vector<impalib_type>> stage_forward_messages_ORIC_project(numProjects_ + 1,
                                                                      vector<impalib_type>(maxStateIc_ + 1, zero_value));
@@ -117,7 +117,7 @@ void OrInequalityConstraint::oric_to_project_eq_constraint_update(vector<vector<
  * 
  */
 
-void OrInequalityConstraint::oric_to_team_update(vector<vector<impalib_type>> &rEqConstraint2OricM,
+void OrInequalityConstraint::oric_to_team_update(const vector<vector<impalib_type>> &rEqConstraint2OricM,
                                                  vector<impalib_type>         &rOric2TeamM)
 {
     for (int team_index = 0; team_index < rOric2TeamM.size(); team_index++)

--- a/include/impalib/update_or_inequality_constraint.hpp
+++ b/include/impalib/update_or_inequality_constraint.hpp
@@ -62,23 +62,18 @@ void OrInequalityConstraint::oric_to_project_eq_constraint_update(vector<vector<
                                                                   vector<vector<impalib_type>> &rEqConstraint2ProjectM,
                                                                   vector<vector<impalib_type>> &rRewardProject)
 {
-    // Initialize forward and backward messages
     vector<vector<impalib_type>> stage_forward_messages_ORIC_project(numProjects_ + 1,
                                                                      vector<impalib_type>(maxStateIc_ + 1, zero_value));
     vector<vector<impalib_type>> stage_backward_messages_ORIC_project(
         numProjects_ + 1, vector<impalib_type>(maxStateIc_ + 1, zero_value));
 
-    // Iterate over each team
     for (int team_index = 0; team_index < numTeams_; team_index++)
     {
 
-        // Initialize forward and backward messages
         vector<impalib_type> initial_forward_messages(maxStateIc_ + 1, zero_value),
             initial_backward_messages(maxStateIc_ + 1, zero_value);
-        
-        // Set initial forward messages
-        fill(initial_forward_messages.begin() + 1, initial_forward_messages.end(), value_inf);
 
+        fill(initial_forward_messages.begin() + 1, initial_forward_messages.end(), value_inf);
         stage_forward_messages_ORIC_project[0] = initial_forward_messages;
         
         // Calculate forward messages
@@ -104,18 +99,13 @@ void OrInequalityConstraint::oric_to_project_eq_constraint_update(vector<vector<
             stage_backward_messages_ORIC_project[stage][1] = stage_backward_messages_ORIC_project[stage + 1][1];
         }
 
-        // Update messages from ORIC to project equality constraints and from project equality constraints to project inequality constraints
         for (int project_index = 0; project_index < numProjects_; project_index++)
         {
             impalib_type minimumValue                      = zero_value;
-            // Calculate the minimum value between forward and backward messages
             minimumValue                                   = min(stage_forward_messages_ORIC_project[project_index][1],
                                                                  stage_backward_messages_ORIC_project[project_index + 1][0]);
-            // Calculate the minimum value between previous minimum and zero
             minimumValue                                   = min(minimumValue, zero_value);
-            // Update messages from ORIC to project equality constraints
             rOric2EqConstraintM[project_index][team_index] = mTeam2ORIC[team_index] - minimumValue;
-            // Update messages from project equality constraints to project inequality constraints
             rEqConstraint2ProjectM[project_index][team_index] =
                 rOric2EqConstraintM[project_index][team_index] + rRewardProject[project_index][team_index];
         }
@@ -133,13 +123,10 @@ void OrInequalityConstraint::oric_to_project_eq_constraint_update(vector<vector<
 void OrInequalityConstraint::oric_to_team_update(vector<vector<impalib_type>> &rEqConstraint2OricM,
                                                  vector<impalib_type>         &rOric2TeamM)
 {
-    // Iterate over each team
     for (int team_index = 0; team_index < rOric2TeamM.size(); team_index++)
     {
-        // Initialize minimum value
         impalib_type minValue = 1000000;
 
-        // Find the minimum value among messages from project equality constraints to ORIC for this team
         for (int project_index = 0; project_index < rEqConstraint2OricM.size(); project_index++)
         {
             if (rEqConstraint2OricM[project_index][team_index] < minValue)
@@ -147,7 +134,6 @@ void OrInequalityConstraint::oric_to_team_update(vector<vector<impalib_type>> &r
                 minValue = rEqConstraint2OricM[project_index][team_index];
             }
         }
-        // Update message from ORIC to team with the minimum value
         rOric2TeamM[team_index] = minValue;
     }
 }

--- a/include/impalib/update_or_inequality_constraint.hpp
+++ b/include/impalib/update_or_inequality_constraint.hpp
@@ -35,9 +35,6 @@ public:
  * @param[in] N_DEPARTMENTS: number of departments
  * @param[in] N_TEAMS: number of teams
  * @param[in] N_PROJECTS: number of projects
- * @param[out] numProjects_: N_PROJECTS
- * @param[out] numTeams_: N_TEAMS
- * @param[out] numDepartments_: N_DEPARTMENTS
  * 
  */
 


### PR DESCRIPTION
## Summary 
We are iteratively going to try to make changes along the lines of our changes in #4, which was a bit too large for a single PR. This PR covers simple changes that cannot break any code.

## Changes
This includes 

- Adding `inline` to function definitions in header files to avoid future linker issues
- Simplifying comments
- Properly `const`-qualifying function parameters and member functions.